### PR TITLE
Adding support for OpenRV push

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -1,13 +1,190 @@
 import os
 import subprocess
-import json
 import re
 import traceback
-import copy
 
 import ftrack_api
 from openpype_modules.ftrack.lib import BaseAction, statics_icon # type: ignore
 
+
+
+def return_pyexec_command(f, *args, **kwargs):
+    """Parse a function source code as a string.
+    
+    f is expected to be a python function.
+    This is a utility function that allows to have syntax highlighting and
+    intelisense while developing code that is going to be sent as a string
+    to be executed somewhere else.
+    """
+    # get source code of function
+    from inspect import getsource
+    src = getsource(f)
+
+    # remove top level indentation in case the funciton is not globally defined
+    tab = re.match("[\t\ ]*(?=def\ )", src).group()
+    if tab:
+        src = "\n".join([l[len(tab):] for l in src.split("\n")])
+    
+    # return the source code as top level function and add execution line
+    parsed_kw = [f"{k}={v}" for k, v in kwargs.items()]
+    signature = f"({', '.join([str(i) for i in [*args, *parsed_kw]])})"
+    return src + f.__name__ + signature + "\n"
+
+def monkey_patch_openrv_gui():
+    """Run inside OpenRV session. Adds combobox for RVSwitch nodes."""
+    from logging import getLogger, basicConfig, INFO, DEBUG
+    from os import environ
+    from PySide2.QtWidgets import QComboBox, QApplication # type: ignore
+    from rv import qtutils as rvq, extra_commands as rvec, commands as rvc # type: ignore
+    # environ["RV_MULTI_MEDIA_REP_DEBUG"] = 1
+    level=DEBUG if "RV_MULTI_MEDIA_REP_DEBUG" in environ else INFO
+    getLogger().setLevel(DEBUG)
+    logger = getLogger("gui_proc")
+
+    app = QApplication.instance() or QApplication()
+    wids = [w for w in app.allWidgets() if isinstance(w, QComboBox)]
+    gen = (w for w in wids if w.objectName() == "22_version_dropdown")
+    try:
+        version_dropdown = next(gen)
+    except StopIteration as e:
+        version_dropdown = None
+
+
+    if version_dropdown is not None:
+        logger.debug(f"Dropdown found.")
+        return
+
+    logger.debug(f"Monkey patching OpenRV GUI as no version dropdown was found.")
+    bottom_toolbar = rvq.sessionBottomToolBar()
+    version_dropdown = QComboBox()
+    version_dropdown.setObjectName("22_version_dropdown")
+    # version_dropdown.addItems(["v021", "v022", "v023"])
+    bottom_toolbar.addWidget(version_dropdown)
+    def update_combobox (event):
+        version_dropdown.clear()
+        version_dropdown.addItems(rvc.nodesOfType("RVSwitchGroup"))
+
+    rvc.bind("default", "global", "new-node", update_combobox, "___doc___")
+    rvc.bind("default", "global", "after-node-deleted", update_combobox, "__doc__")
+    logger.debug(f"All done.")
+    
+    def on_item_clicked(text):
+        info = rvec.sourceMetaInfoAtFrame(rvc.frame())
+        # logger.debug(info)
+        src_node = rvc.sourceMediaRepSourceNode(info["node"])
+        # logger.debug(f"Current source node is {src_node}")
+        switch_node = rvc.sourceMediaRepSwitchNode(src_node)
+        # logger.debug(f"Current switch node is {switch_node}.")
+        rvc.setViewNode(text)
+
+    try:
+        version_dropdown.currentTextChanged.disconnect()
+    except Exception as e:
+        ...
+
+    version_dropdown.textActivated.connect(on_item_clicked)
+
+def orvpush_proc(items):
+    """Main function to be run inside OpenRV.
+    
+    This function must be parsed with the 'return_pyexec_command' before
+    being sent over.
+    Because this function is executed in another interpreter, global
+    variables won't be inherited in this scope, which means that
+    all imports must happen in the local scope.
+    """
+
+    from logging import getLogger
+    from pathlib import Path
+    from re import compile as recomp
+
+    import rv.commands as rvc # type: ignore
+
+    logger = getLogger("orvpush_proc")
+    SHOT_REGEX = recomp(r"(?<=\_)\d{3}\_\d{3}(?=\_)")
+
+
+
+    def flatten_input_list(items: list):
+        """Adapt paths so it matches rvpush needs.
+        TODO: when rvpush is  approved, refactor the function that
+        generates the list of items so that it matches rvpush
+        instead of rv so that we dont need the lines down below
+        """
+        inputs = list()
+        for group in items:
+            for string in group:
+                for substring in string.split(" "):
+                    if len(substring) < 5:
+                        logger.debug(f"Ignoring substring {substring}")
+                        continue
+                    elif Path(substring.replace(".#.", ".1001.")).exists():
+                        logger.debug(f"Adding file {substring}")
+                        inputs.append(Path(substring))
+                    else:
+                        logger.debug(f"Ignoring file {substring} as it doesnt exists")
+        return inputs
+
+    inputs = flatten_input_list(items)
+
+    def is_source_in_rv_session(f: Path):
+        """Checks whether a path file is already imported.
+        TODO: if file was imported outside of pipeline, it will return true,
+        but the file won't appear in any switch node.
+        """
+        for src in rvc.sources():
+            if src is None:
+                continue
+            p = Path(src[0])
+            if p.parent == f.parent and p.suffix == f.suffix:
+                return True
+        return False
+
+
+    rvc.addSourceBegin() # halt new sources connections
+
+    # iterate over the component paths [[], [], []]
+    for f in inputs:
+        logger.debug(f"working on {f}")
+
+        if is_source_in_rv_session(f):
+            continue
+                      
+        tag = f.name
+        shot = SHOT_REGEX.findall(f.stem)[0]
+
+        # iterate over existing sources and look for shot groups
+        for switch_node in rvc.nodesOfType("RVSwitch"):
+            try:
+                src_node = rvc.sourceMediaRepSourceNode(switch_node)
+                src = Path(rvc.sourceMedia(src_node)[0])
+            except Exception as e:
+                continue
+            
+            sh = SHOT_REGEX.findall(Path(src).stem)[0]
+            
+            logger.debug(f"Match found for incoming file and existing switch node.")
+            if sh == shot:
+                args = [f.as_posix()]
+                if f.suffix in [".exr", ".jpg", ".jpeg"]:
+                    args += ["+in", "1001"]
+                try:
+                    rvc.addSourceMediaRep(src_node, tag, args)
+                    logger.debug(f"Reused switch node {switch_node} @ {shot}:")
+                except Exception as e:
+                    logger.warning(f"Error {e} found... Check with dev team.")
+                    pass
+                break
+        else:
+            logger.debug(f"Creating new switch node.")
+            args = [f.as_posix(), "+mediaRepName", tag]
+            if f.suffix in [".exr", ".jpg", ".jpeg"]:
+                args += ["+in", "1001"]
+            src = rvc.addSourceVerbose(args)
+            logger.debug(f"New switch node created {src} @ {shot}:")
+
+    rvc.addSourceEnd() # start connecting all new sources
+    logger.debug('ERROR: This message will not be color coded.')
 
 class ORVAction(BaseAction):
     """ Launch ORV action """
@@ -171,7 +348,6 @@ class ORVAction(BaseAction):
         
         return path_list
 
-
     def parse_file(self, component_location, no_slate = False):
 
         path = os.path.abspath(
@@ -207,6 +383,8 @@ class ORVAction(BaseAction):
                 "value": component
             })
         enum_data = sorted(enum_data, key = lambda d: d["value"], reverse = True)
+        if not enum_data:
+            raise IndexError("Failed to fetch any components")
         items = []
         items.extend(
             [
@@ -338,187 +516,17 @@ class ORVAction(BaseAction):
         paths = self.get_pathlist(
             component_paths, prev_component_paths, no_slate)
 
-
-        def return_pyexec_command(f, *args, **kwargs):
-            """Parse a function source code as a string.
-            
-            f is expected to be a python function.
-            This is a utility function that allows to have syntax highlighting and
-            intelisense while developing code that is going to be sent as a string
-            to be executed somewhere else.
-            """
-            # get source code of function
-            from inspect import getsource
-            src = getsource(f)
-
-            # remove top level indentation in case the funciton is not globally defined
-            tab = re.match("[\t\ ]*(?=def\ )", src).group()
-            if tab:
-                src = "\n".join([l[len(tab):] for l in src.split("\n")])
-            
-            # return the source code as top level function and add execution line
-            parsed_kw = [f"{k}={v}" for k, v in kwargs.items()]
-            signature = f"({', '.join([str(i) for i in [*args, *parsed_kw]])})"
-            return src + f.__name__ + signature + "\n"
-    
-        def monkey_path_openrv_gui():
-            from PySide2.QtWidgets import QComboBox, QApplication # type: ignore
-            from rv import qtutils as rvq, extra_commands as rvec, commands as rvc # type: ignore
-
-            app = QApplication.instance() or QApplication()
-            wids = [w for w in app.allWidgets() if isinstance(w, QComboBox)]
-            gen = (w for w in wids if w.objectName() == "22_version_dropdown")
-            try:
-                version_dropdown = next(gen)
-            except StopIteration as e:
-                version_dropdown = None
-
-
-            if version_dropdown is None:
-                print(f"Monkey patching OpenRV GUI as no version dropdown was found.")
-                bottom_toolbar = rvq.sessionBottomToolBar()
-                version_dropdown = QComboBox()
-                version_dropdown.setObjectName("22_version_dropdown")
-                # version_dropdown.addItems(["v021", "v022", "v023"])
-                bottom_toolbar.addWidget(version_dropdown)
-                def update_combobox (event):
-                    version_dropdown.clear()
-                    version_dropdown.addItems(rvc.nodesOfType("RVSwitchGroup"))
-
-                rvc.bind("default", "global", "new-node", update_combobox, "___doc___"); 
-                rvc.bind("default", "global", "after-node-deleted", update_combobox, "__doc__"); 
-            
-            def on_item_clicked(text):
-                info = rvec.sourceMetaInfoAtFrame(rvc.frame())
-                print(info)
-                src_node = rvc.sourceMediaRepSourceNode(info["node"])
-                print(f"Current source node is {src_node}")
-                switch_node = rvc.sourceMediaRepSwitchNode(src_node)
-                print(f"Current switch node is {switch_node}.")
-                rvc.setViewNode(text)
-
-            try:
-                version_dropdown.currentTextChanged.disconnect()
-            except Exception as e:
-                ...
-
-            version_dropdown.textActivated.connect(on_item_clicked)
-
-        def orvpush_proc(items):
-            """Main function to be run inside OpenRV.
-            
-            This function must be parsed with the 'return_pyexec_command' before
-            being sent over.
-            Because this function is executed in another interpreter, global
-            variables won't be inherited in this scope, which means that
-            all imports must happen in the local scope.
-            """
-
-            from pathlib import Path
-            from re import compile as recomp
-            import rv.commands as rvc # type: ignore
-
-
-
-            # adapt paths so it matches rvpush
-            # TODO: when rvpush is  approved, refactor the function that
-            # generates the list of items so that it matches rvpush
-            # instead of rv so that we dont need the lines down below
-            inputs = list()
-            for group in items:
-                for string in group:
-                    for substring in string.split(" "):
-                        if len(substring) < 5:
-                            print(f"Ignoring substring {substring}")
-                            continue
-                        elif Path(substring.replace(".#.", ".1001.")).exists():
-                            print(f"Adding file {substring}")
-                            inputs.append(Path(substring))
-                        else:
-                            print(f"Ignoring file {substring} as it doesnt exists")
-
-            SHOT_REGEX = recomp(r"(?<=\_)\d{3}\_\d{3}(?=\_)")
-
-            # iterate over the component paths [[], [], []]
-            rvc.addSourceBegin() # halt new sources connections
-
-            for f in inputs:
-                print(f"working on {f}")
-
-                # if already loaded, skip
-                if any(f == p for p in [Path(src[0]) for src in rvc.sources() if src]):
-                    # print(f"File already loaded: {f}")
-                    continue
-
-                tag = f.name
-                shot = SHOT_REGEX.findall(f.stem)[0]
-
-                # iterate over existing sources and look for shot groups
-                for switch_node in rvc.nodesOfType("RVSwitch"):
-                    try:
-                        src_node = rvc.sourceMediaRepSourceNode(switch_node)
-                        src = Path(rvc.sourceMedia(src_node)[0])
-                    except Exception as e:
-                        continue
-                    
-                    sh = SHOT_REGEX.findall(Path(src).stem)[0]
-                    
-                    print(sh, shot)
-                    if sh == shot:
-                        args = [f.as_posix()]
-                        if f.suffix in [".exr", ".jpg", ".jpeg"]:
-                            args += ["+in", "1001"]
-                        try:
-                            rvc.addSourceMediaRep(rvc.sourceMediaRepSourceNode(switch_node), tag, args)
-                        except:
-                            pass
-                        break
-                else:
-                    args = [f.as_posix(), "+mediaRepName", tag]
-                    if f.suffix in [".exr", ".jpg", ".jpeg"]:
-                        args += ["+in", "1001"]
-                    
-            src = rvc.addSourceVerbose(args)
-                    
- 
-
-
-            # for group in items:
-            #     for i, path in enumerate(group):
-
-            #         # if already loaded, skip
-            #         if any(Path(path) == p for p in all_sources):
-            #             print(f"File already loaded: {path}")
-            #             continue
-
-            #         tag = Path(path).name
-
- 
-
-
-
-            #         path_arg = [path.split(" ")[-1], *path.split(" ")[:-1]]
-            #         path_arg += ["+mediaRepName", tag]
-            #         path_arg = ["+in" if i == "-in" else i for i in path_arg]
-            #         # print(path_arg)
-
-            #         if i == 0:
-            #             src = rvc.addSourceVerbose(path_arg)
-            #             print(f"Created source {src}")
-            #         else:
-            #             rvc.addSourceMediaRep(src, tag, [path])
-            rvc.addSourceEnd() # start connecting all new sources
-                
-
+        # START OF OPENRVPUSH PROC
         # generate dropdown on the fly
-        src1 = return_pyexec_command(monkey_path_openrv_gui)
+        src1 = return_pyexec_command(monkey_patch_openrv_gui)
         # src1 = ""
 
         # leverage multimedia sources feature as version switcher
         src2 = return_pyexec_command(orvpush_proc, paths)
         cmd = [self.orvpush_path, "py-exec", src1 + src2]
-        # self.log.info(f"Running ORVPUSH: {cmd}")
+        self.log.debug(f"Running ORVPUSH: {cmd}")
         rv_push_process = subprocess.Popen(cmd)
+        # END OF OPENRVPUSH PROC
 
         # args.append(self.orv_path)
 

--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -2,13 +2,14 @@ import os
 import subprocess
 import re
 import traceback
+from typing import Callable, List
 
 import ftrack_api
 from openpype_modules.ftrack.lib import BaseAction, statics_icon # type: ignore
 
 
 
-def return_pyexec_command(f, *args, **kwargs):
+def return_pyexec_command(f: Callable, *args, **kwargs):
     """Parse a function source code as a string.
     
     f is expected to be a python function.
@@ -84,7 +85,7 @@ def monkey_patch_openrv_gui():
 
     version_dropdown.textActivated.connect(on_item_clicked)
 
-def orvpush_proc(items):
+def orvpush_proc(items: List[List[str]]):
     """Main function to be run inside OpenRV.
     
     This function must be parsed with the 'return_pyexec_command' before
@@ -105,7 +106,7 @@ def orvpush_proc(items):
 
 
 
-    def flatten_input_list(items: list):
+    def flatten_input_list(items: List[List[str]]):
         """Adapt paths so it matches rvpush needs.
         TODO: when rvpush is  approved, refactor the function that
         generates the list of items so that it matches rvpush

--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -519,7 +519,7 @@ class ORVAction(BaseAction):
 
         # START OF OPENRVPUSH PROC
         # generate dropdown on the fly
-        src += "from typing import Callable, List\n"
+        src = "from typing import Callable, List\n"
         src += return_pyexec_command(monkey_patch_openrv_gui)
 
         # leverage multimedia sources feature as version switcher

--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -79,7 +79,7 @@ def monkey_patch_openrv_gui():
         rvc.setViewNode(text)
 
     try:
-        version_dropdown.currentTextChanged.disconnect()
+        version_dropdown.textActivated.disconnect()
     except Exception as e:
         ...
 
@@ -519,12 +519,12 @@ class ORVAction(BaseAction):
 
         # START OF OPENRVPUSH PROC
         # generate dropdown on the fly
-        src1 = return_pyexec_command(monkey_patch_openrv_gui)
-        # src1 = ""
+        src += "from typing import Callable, List\n"
+        src += return_pyexec_command(monkey_patch_openrv_gui)
 
         # leverage multimedia sources feature as version switcher
-        src2 = return_pyexec_command(orvpush_proc, paths)
-        cmd = [self.orvpush_path, "py-exec", src1 + src2]
+        src += return_pyexec_command(orvpush_proc, paths)
+        cmd = [self.orvpush_path, "py-exec", src]
         self.log.debug(f"Running ORVPUSH: {cmd}")
         rv_push_process = subprocess.Popen(cmd)
         # END OF OPENRVPUSH PROC


### PR DESCRIPTION
## Changelog Description
Modified logic so that it uses rvpush instead of rv for opening files.
Additionally added support for leveraging the Multiple Media Representation  switch nodes to switch between different versions of a given shot.
Added support for logging inside the RV session.
Fixed minor bugs regarding components not found.

## Additional info
In later sessions some of the logic may be offloaded to RV packages so Monkey patching is not needed.
Some logic should be moved to a different repo so that it can be reused, like the ftrack functions.
We should add type hints and better docstrings.
Debug mode was hardcoded for the python logging root.

## Testing notes:
1. No tests were added, as it mostly relies on external API calls.
