### PR TITLE
adding support for assetversionlists in action_delivery

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_delivery.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delivery.py
@@ -37,7 +37,7 @@ class Delivery(BaseAction):
     def discover(self, session, entities, event):
         is_valid = False
         for entity in entities:
-            if entity.entity_type.lower() in ("assetversion", "reviewsession"):
+            if entity.entity_type.lower() in ("assetversion", "reviewsession", "assetversionlist"):
                 is_valid = True
                 break
 
@@ -261,23 +261,42 @@ class Delivery(BaseAction):
     def _extract_asset_versions(self, session, entities):
         asset_version_ids = set()
         review_session_ids = set()
+        asset_version_list_ids = set()
+
         for entity in entities:
             entity_type_low = entity.entity_type.lower()
+
             if entity_type_low == "assetversion":
                 asset_version_ids.add(entity["id"])
+
             elif entity_type_low == "reviewsession":
                 review_session_ids.add(entity["id"])
+
+            elif entity_type_low == "assetversionlist":
+                asset_version_list_ids.add(entity["id"])
+
+        for version_id in self._get_asset_version_ids_from_asset_ver_list(
+            session, asset_version_list_ids
+        ):
+            asset_version_ids.add(version_id)
 
         for version_id in self._get_asset_version_ids_from_review_sessions(
             session, review_session_ids
         ):
             asset_version_ids.add(version_id)
 
-        asset_versions = session.query((
-            "select id, version, asset_id from AssetVersion where id in ({})"
-        ).format(self.join_query_keys(asset_version_ids))).all()
+        qkeys = self.join_query_keys(asset_version_ids)
+        query = "select id, version, asset_id, incoming_links"
+        query += f" from AssetVersion where id in ({qkeys})"
+        asset_versions = session.query(query).all()
 
-        return asset_versions
+        filtered_ver = list()
+        for asset_version in asset_versions:
+            version_links = list(asset_version["incoming_links"]) or [asset_version]
+            filtered_ver.append(version_links[0])
+
+        return filtered_ver
+
 
     def _get_asset_version_ids_from_review_sessions(
         self, session, review_session_ids
@@ -293,6 +312,19 @@ class Delivery(BaseAction):
             review_session_object["version_id"]
             for review_session_object in review_session_objects
         }
+
+
+    def _get_asset_version_ids_from_asset_ver_list( self, session, asset_ver_list_ids):
+        # this can be static method..
+        if not asset_ver_list_ids:
+            return set()
+
+        ids = ", ".join(asset_ver_list_ids)
+        query_str = f"select id from AssetVersion where lists any (id in ({ids}))"
+        asset_versions = session.query(query_str).all()
+
+        return {asset_version["id"] for asset_version in asset_versions}
+
 
     def _get_version_docs(
         self,


### PR DESCRIPTION
Making improvements to the Ftack OP action `action_delivery.py`

1. adding forwarding of delivery assetversion for action_delivery, so if a version that is not delivery is used for a delivery, it checks whether there is a delivery version and sends that instead
2. adding support for assetversionlists in action_delivery, so that users can deliver all version from an assetversionlist

### TODO:
1. MA requested for OpenRV to have one session per project, isntead if all in the same session