### PR TITLE
Fixing notes creation bug

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_ttd_create_derived_list.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_ttd_create_derived_list.py
@@ -141,6 +141,25 @@ class CreateDerivedListAction(BaseAction):
             return
         
         self.log.info("Sumbitted choices: {}".format(user_values))
+        list_name = user_values["list_name"]
+        all_asset_version_lists = session.query(
+            "select name from AssetVersionList "
+            f"where project.id is {entities[0]['project']['id']}").all()
+        all_review_sessions = session.query(
+            "select name from ReviewSession "
+            f"where project.id is {entities[0]['project']['id']}").all()
+
+
+
+        existing_names = [l["name"] for l in all_asset_version_lists]
+
+        if user_values["client_review"]:
+            existing_names = [l["name"] for l in all_review_sessions]
+
+        if list_name in existing_names:
+            return {
+                "success": False,
+                "message": f"Error: List name '{list_name}' exists already."}
 
         created_list = create_list(
             session,

--- a/openpype/modules/ftrack/event_handlers_user/action_ttd_create_derived_list.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_ttd_create_derived_list.py
@@ -153,10 +153,11 @@ class CreateDerivedListAction(BaseAction):
             log = self.log
         )
 
-        self.log.debug("Created '{}' named '{}'".format(
-            created_list.entity_type,
-            created_list["name"]
-        ))
+        if create_list:
+            self.log.debug("Created '{}' named '{}'".format(
+                created_list.entity_type,
+                created_list["name"]
+            ))
 
         return {"success": True, "message": "Creation successful!"}
 

--- a/openpype/modules/ftrack/lib/__init__.py
+++ b/openpype/modules/ftrack/lib/__init__.py
@@ -24,7 +24,7 @@ from . import credentials
 from .ftrack_base_handler import BaseHandler
 from .ftrack_event_handler import BaseEvent
 from .ftrack_action_handler import BaseAction, ServerAction, statics_icon
-from .ftrack_shared_funcs import create_list
+from .ftrack_shared_funcs import create_list, create_notes
 
 
 __all__ = (
@@ -57,5 +57,6 @@ __all__ = (
     "ServerAction",
     "statics_icon",
 
-    "create_list"
+    "create_list",
+    "create_notes"
 )

--- a/openpype/modules/ftrack/lib/ftrack_shared_funcs.py
+++ b/openpype/modules/ftrack/lib/ftrack_shared_funcs.py
@@ -1,5 +1,138 @@
 from logging import getLogger
-import ftrack_api
+from typing import List
+from tempfile import gettempdir
+from urllib.request import urlopen
+from shutil import copyfileobj
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+from ftrack_api.entity.component import Component
+from ftrack_api.entity.note import Note
+from ftrack_api.entity.location import Location
+from ftrack_api import Session
+from ftrack_api.entity.base import Entity
+
+
+matching_fields = [
+    "content",
+    "project_id",
+    "parent_type",
+    "category_id",
+    "user_id",
+    ]
+
+def duplicate_ftrack_server_component(comp: Component, session: Session):
+
+    # server_location: Location = Session().get('Location', symbol.SERVER_LOCATION_ID)
+
+    for cloc in comp["component_locations"]:
+
+        if cloc["location"]["name"] == "ftrack.server":
+            server_location: Location = cloc['location']
+            logger.info(f"Fetching component from location {cloc['location']}")
+            try:
+                url = server_location.get_url(comp)
+            except Exception as e:
+                logger.info(f"Failed to retrieve url for {comp} in {server_location} due to {e}")
+                raise (e)
+            name = comp["name"] + comp["file_type"]
+            f = gettempdir() + "/" + name
+            logger.info(f"Creating component from temp file: {f}")
+
+            with urlopen(url) as response, open(f, 'wb') as out_file:
+                copyfileobj(response, out_file)
+        else:
+            logger.info(f"Ignoring location {cloc['location']['name']}")
+            # it is unmanaged, maybe the source is locally and thus inaccesible
+            continue
+        return session.create_component(f, {"name":name}, location=cloc["location"])
+
+
+def transfer_note_components(note_src: Note, note_target: Note, session: Session):
+    for note_comp in note_src["note_components"]:
+        logger.info(f"Working on component {note_comp}")
+        comp = note_comp["component"]
+        if any(comp["name"] != c["component"] for c in note_target["note_components"]):
+            logger.info(f"This component was already copied {comp['name']}")
+            continue
+        try:
+            new_component = duplicate_ftrack_server_component(comp, session)
+        except Exception as e:
+            logger.info(f"Failed to copy component {comp} due to {e}")
+            continue
+        if new_component is None:
+            continue
+        session.create("NoteComponent", {"component_id":new_component["id"], "note_id": note_target["id"]})
+
+
+def create_notes(
+    session: Session, src_note: Note, target: Entity, notes_in_target: List[Note]
+    ):
+    msg = ""
+    # REMOVE ALREADY MATCHING NOTES IN TARGET
+    for target_note in notes_in_target:
+        if  all(src_note[f] == target_note[f] for f in matching_fields):
+
+            logger.info(
+                f"Note already copied. {src_note} -> {target_note}, "
+                f"removing it. Content is: {src_note['content']}"
+            )
+            session.delete(target_note)
+    else:
+        replies = [
+            session.create(
+                "Note",
+                {tag: reply[tag] for tag in matching_fields}
+                ) for reply in src_note["replies"]
+            ]
+
+        logger.info("Note components are:", list(src_note["note_components"]))
+
+        r = session.create("Note", {
+            **{tag: src_note[tag] for tag in matching_fields},
+            "parent_id": target["id"],
+            "replies": replies,
+            # "note_label_links" : note_label_links,
+            })
+        
+        transfer_note_components(src_note, r, session)
+
+        for i, reply in enumerate(src_note["replies"]):
+            transfer_note_components(reply, r["replies"][i], session)
+
+        logger.info(f"Updated client notes for version_id {target['id']}")
+        msg += f"Updated client notes for version {target['id']}"
+    return msg
+
+
+def copy_client_notes(session: Session, review_items: List[Entity]):
+    
+    sources = [rev["asset_version"] for rev in review_items]
+    versions_ids = f"({', '.join([v['id'] for v in sources])})"
+    versions_by_id = {v["id"]: v for v in sources}
+
+    select = "select author, category, content, in_reply_to, category.name, parent_id"
+    where = f"where parent_id in {versions_ids} and in_reply_to is None and category.name is \"For Client\""
+
+    notes = session.query(f"{select} from Note {where}").all()
+
+    msg = ""
+
+    for note in notes:
+
+        source = versions_by_id[note["parent_id"]]
+        target = next(r for r in review_items if r["asset_version"] == source)
+
+        logger.info(f"Working on note {note} from version {source}")
+        notes_in_target = [n for n in notes if n["parent_id"] == target["id"]]
+
+        logger.info(f"Target notes are: {notes_in_target}")
+        msg += create_notes(session, note, target, notes_in_target)
+
+    session.commit()
+    return msg
+
 
 
 def create_list(session,
@@ -90,7 +223,7 @@ def create_list(session,
         review_session_folder["review_sessions"].append(review_session)
         log.debug("Created Review Session '{}/{}'".format(
             list_category["name"], list_name))
-
+        review_items = list()
         for fav in final_assetversions:
             created_review_object = session.create("ReviewSessionObject", {
                 "asset_version": fav,
@@ -99,14 +232,16 @@ def create_list(session,
                 "description": fav["comment"],
                 "version": "Version {}".format(str(fav["version"]).zfill(3))
             })
-            created_review_object["notes"].extend(
-                [n for n in fav["notes"]]
-            )
+            review_items.append(created_review_object)
+            # created_review_object["notes"].extend(
+            #     [n for n in fav["notes"]]
+            # )
             log.debug("Appended version '{} v{}' to created review session: {}".format(
                 fav["asset"]["name"],
                 fav["version"],
                 created_review_object["name"]
             ))
+        copy_client_notes(session, review_items)
 
     else:
         list_data = {

--- a/openpype/modules/ftrack/lib/ftrack_shared_funcs.py
+++ b/openpype/modules/ftrack/lib/ftrack_shared_funcs.py
@@ -67,7 +67,6 @@ def transfer_note_components(note_src: Note, note_target: Note, session: Session
             logger.info(f"No new component was returned")
             continue
         session.create("NoteComponent", {"component_id":new_component["id"], "note_id": note_target["id"]})
-        session.commit()
 
 
 def create_notes(
@@ -91,7 +90,7 @@ def create_notes(
                 ) for reply in src_note["replies"]
             ]
 
-        logger.info("Note components are:", list(src_note["note_components"]))
+        logger.info(f"Note components are: {list(src_note['note_components'])}")
 
         r = session.create("Note", {
             **{tag: src_note[tag] for tag in matching_fields},


### PR DESCRIPTION
bugfixing the error where the notes where moved from the source assetversion into the target reviewsessionobject. Now it clones notes so that they are different entities.
Gracefully exisiting create list action if the name chosen is already in use