### PR TITLE
OpenRV: fix for when project attr is not found in OpenRV

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import re
 import traceback
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Optional
 from pathlib import Path
 
 import ftrack_api
@@ -139,7 +139,8 @@ class ORVAction(BaseAction):
             "component.version.asset.name,",
             "component.version.asset.parent.name,",
             "component.version.asset.versions,",
-            "component.version.asset.latest_version",
+            "component.version.asset.latest_version,",
+            "component.version.project.name ",
             "from ComponentLocation",
             # f" where component.name is {component_name}",
             f"where (component.name is {component_name} or {name_match})",
@@ -194,7 +195,12 @@ class ORVAction(BaseAction):
                 seen.append(cpath['component']["version_id"])
                 yield path.as_posix(), cpath["component"]["version"]["asset"]["parent"]["name"]
 
-    def get_interface(self, available_components, is_manual_selection = False):
+    def get_interface(
+            self,
+            available_components: List[str],
+            is_manual_selection: bool = False,
+            preference: str = "exr"
+            ):
         """ Returns correctly formed interface elements """
         enum_data = []
         for component in available_components:
@@ -202,7 +208,8 @@ class ORVAction(BaseAction):
                 "label": component,
                 "value": component
             })
-        enum_data = sorted(enum_data, key = lambda d: not "exr"==d["label"])
+        
+        enum_data = sorted(enum_data, key = lambda d: not preference==d["label"])
         if not enum_data:
             raise IndexError("Failed to fetch any components")
         items = []
@@ -250,7 +257,7 @@ class ORVAction(BaseAction):
                     "label": "<div><b>Remove slate</b></div><div style=\"font-size: 8pt;\">(Only works for sequences)</div>",
                     "type": "boolean",
                     "name": "no_slate",
-                    "value": True
+                    "value": False
                 },
                 {
                     "label": "<div><b>Load previous version</b></div><div style=\"font-size: 8pt;\">(All components)</div>",
@@ -291,8 +298,12 @@ class ORVAction(BaseAction):
             assetversions = self.get_all_assetversions(session, entities)
             available_components = self.get_all_available_components(
                 session, assetversions, self.allowed_types)
-            items = self.get_interface(
-                available_components, is_manual_selection)
+
+            preference = "exr"
+            if entities[0].entity_type == "FileComponent":
+                preference = entities[0]["name"]
+
+            items = self.get_interface( available_components, is_manual_selection, preference)
             return {
                 "items": items,
                 "width": 500,
@@ -379,12 +390,11 @@ class ORVAction(BaseAction):
         src = "from openrv_tools_22dogs import orvpush_inputs_callback\n"
         signature = f"({', '.join([str(i) for i in [paths, no_slate, fps]])})"
         src += "orvpush_inputs_callback" + signature
-        try:
+
+        if entities[0].entity_type == "FileComponent":
+            prj = entities[0]["version"]["project"]["full_name"]
+        else:
             prj = entities[0]["project"]["full_name"]
-        except KeyError as e:
-            self.log.critical(f"Failed to find project attr for entity {entities[0]}")
-            self.log.critical("Please report this to pipeline.")
-            prj = "error_project"
 
         cmd = [self.orvpush_path, "-tag", prj, "py-exec", src]
         self.log.debug(f"Running ORVPUSH: {cmd}")

--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -379,7 +379,12 @@ class ORVAction(BaseAction):
         src = "from openrv_tools_22dogs import orvpush_inputs_callback\n"
         signature = f"({', '.join([str(i) for i in [paths, no_slate, fps]])})"
         src += "orvpush_inputs_callback" + signature
-        prj = entities[0]["project"]["full_name"]
+        try:
+            prj = entities[0]["project"]["full_name"]
+        except KeyError as e:
+            self.log.critical(f"Failed to find project attr for entity {entities[0]}")
+            self.log.critical("Please report this to pipeline.")
+            prj = "error_project"
 
         cmd = [self.orvpush_path, "-tag", prj, "py-exec", src]
         self.log.debug(f"Running ORVPUSH: {cmd}")


### PR DESCRIPTION
Hotfix when the project attr is not found in OpenRV entities selected for playing with OpenRV
