### PR TITLE
Adding fallback in case the delivery template fails to be resolved

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_delivery.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delivery.py
@@ -736,11 +736,15 @@ class Delivery(BaseAction):
                                                             anatomy_data,
                                                             datetime_data,
                                                             anatomy_name)
+
                 if not new_repre_report_items:
-                    msg = "Template override failed: fallback template applied. Delivery was successfull."
-                    submsg = f"The delivery was done but the used template used is: "\
-                    f"\n\n{original_template} \n\ninstead of \n\n{template_override}"
-                    f"The original error was {repre_report_items}"
+                    resolved = anatomy.format_all({**anatomy_data, **datetime_data})
+                    resolved = Path(resolved["delivery"][anatomy_name]).parent.parent
+                    msg = f"Delivery was successfull but the template override "\
+                    f"\"{anatomy_name}\" failed: delivery used the default config."
+                    submsg = f"The delivery was done but the template used"\
+                    f" for \"{anatomy_name}\" is <br><br>{resolved}<br><br>"\
+                    f"The original error was: <br><br>{repre_report_items}"
                     report_items[msg] = submsg
                     repre_report_items = dict()
 


### PR DESCRIPTION
When a project has a delivery template override, if it fails to be resolved and there is a default for that template, it will fallback into that template instead of the override that failed.

If there is no default for that override it will fail as it failed before



WITH DEFAULT TO FALLBACK:
![imagen](https://github.com/maxpareschi/OpenPype/assets/166030421/a8dc3486-168e-4cd0-a452-967f11977086)

WITHOUT DEFAULT FALLBACK
![imagen](https://github.com/maxpareschi/OpenPype/assets/166030421/fb0eeaf1-1d3a-44a1-82b3-e4e718aa1cc1)

