### PR TITLE
adding several defaults for avalon_mongo_id read

### DIFF
--- a/openpype/settings/defaults/system_settings/modules.json
+++ b/openpype/settings/defaults/system_settings/modules.json
@@ -86,7 +86,14 @@
                     ],
                     "read_security_roles": [
                         "API",
-                        "Administrator"
+                        "Administrator",
+                        "VFX_Editor",
+                        "Supervisor",
+                        "Project Manager",
+                        "Pipeline_TD",
+                        "Producer",
+                        "megarole",
+                        "pypeclub"
                     ]
                 },
                 "fps": {


### PR DESCRIPTION
The avalon_mongo_id attribute should be readed by all roles... but when we update the pipe, these permissions get reseted.
Now this permision would be reseted with more open values.