### PR TITLE
Improving delivery action

### DIFF
--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -15,7 +15,8 @@ def augment_representation_context(prj: str, repre: dict, context: dict):
     start = asset["data"]["frameStart"] - asset["data"]["handleStart"]
     end = asset["data"]["frameEnd"] + asset["data"]["handleEnd"]
     context["asset_data"] = deepcopy(asset["data"])
-    context["asset_data"]["duration"] = end - start
+    context["asset_data"]["duration"] = end - start + 2
+    context["asset_data"]["duration_no_slate"] = end - start + 1
     context["asset_data"]["start"] = start
     context["asset_data"]["end"] = end
 

--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -25,10 +25,18 @@ def generate_csv_line_from_repre(
     data = deepcopy(repre["context"])
     data["root"] = anatomy.roots
     data.update(datetime_data)
-    template = ",".join([d["column_value"] for d in settings])
+    # template = ",".join([d["column_value"] for d in settings])
     augment_representation_context(prj, repre, data)
-    path = StringTemplate.format_strict_template(template, data)
-    return path
+    row =  ""
+    for item in settings:
+        t = item["column_value"]
+        try:
+            value = StringTemplate.format_strict_template(t, data)
+        except:
+            value = "null"
+        row = row + value + ","
+    return row[:-1]
+
 
 
 def yield_csv_lines_from_representations(prj: str, representations: List[dict]):

--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -39,19 +39,23 @@ def generate_csv_line_from_repre(
 
 
 
-def yield_csv_lines_from_representations(prj: str, representations: List[dict]):
+def yield_csv_lines_from_representations(
+        prj: str, representations: List[dict], anatomy_name: str):
     anatomy = Anatomy(prj)
     datetime_data = get_datetime_data()
     settings = get_project_settings(prj)["ftrack"]["user_handlers"]
-    settings = settings["delivery_action"]["delivery_csv_items"]
+    settings = settings["delivery_action"]["csv_template_families"].get(anatomy_name)
+    if settings is None:
+        settings = [{"column_name":"Errors", "column_value":"Failed to find CSV config"}]
     yield ",".join([d["column_name"] for d in settings])
     for repre in representations:
         yield generate_csv_line_from_repre(prj, repre, anatomy, datetime_data, settings)
 
 
-def generate_csv_from_representations(prj: str, representations: List[dict], csv_path: Union[Path, str]):
+def generate_csv_from_representations(
+        prj: str, representations: List[dict], csv_path: Union[Path, str], anatomy_name: str):
     csv = Path(csv_path)
     print(f"Generating csv file {csv}, {csv.parent}")
     csv.parent.mkdir(exist_ok=True, parents=True)
-    lines = "\n".join(yield_csv_lines_from_representations(prj, representations))
+    lines = "\n".join(yield_csv_lines_from_representations(prj, representations, anatomy_name))
     csv.write_text(lines)

--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -33,7 +33,7 @@ def generate_csv_line_from_repre(
         try:
             value = StringTemplate.format_strict_template(t, data)
         except:
-            value = "null"
+            value = ""
         row = row + value + ","
     return row[:-1]
 
@@ -51,6 +51,7 @@ def yield_csv_lines_from_representations(prj: str, representations: List[dict]):
 
 def generate_csv_from_representations(prj: str, representations: List[dict], csv_path: Union[Path, str]):
     csv = Path(csv_path)
+    print(f"Generating csv file {csv}, {csv.parent}")
     csv.parent.mkdir(exist_ok=True, parents=True)
     lines = "\n".join(yield_csv_lines_from_representations(prj, representations))
     csv.write_text(lines)

--- a/openpype/modules/ftrack/event_handlers_user/action_delivery.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delivery.py
@@ -52,7 +52,11 @@ def return_version_notes_for_csv(version):
     for note in version["notes"]:
         if note["in_reply_to"]:
             continue
-        content = note["content"] + " ->REPLY-> ".join([n["content"] for n in note["replies"]]) + " "*4
+        content = note["content"]
+        
+        if note["replies"]:
+            replies = "  ".join([n["content"] for n in note["replies"]]) + " "*4
+            content = content + " ->REPLIES-> " + replies
         result[note["category"]["name"]] += content
     return result
 

--- a/openpype/modules/ftrack/event_handlers_user/action_delivery.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delivery.py
@@ -9,6 +9,7 @@ import collections
 from pathlib import Path
 from logging import getLogger
 import webbrowser
+from datetime import datetime
 from tempfile import NamedTemporaryFile
 
 logger = getLogger(__name__)
@@ -82,7 +83,8 @@ def create_csv_in_download_folder(
     lines = "\n".join(
         yield_csv_lines_from_representations(project_name, repres_to_deliver, anatomy_name
         ))
-    dl_dir = Path.home() / f'Downloads/{name}.csv'
+    filename = datetime.now().strftime("%Y%m%d_%H_%M") + "_delivery_data"
+    dl_dir = Path.home() / f'Downloads/{name or filename}.csv'
     dl_dir.write_text(lines)
     webbrowser.open(dl_dir)
 

--- a/openpype/modules/ftrack/event_handlers_user/action_delivery.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delivery.py
@@ -55,8 +55,8 @@ def return_version_notes_for_csv(version):
         content = note["content"]
         
         if note["replies"]:
-            replies = "  ".join([n["content"] for n in note["replies"]]) + " "*4
-            content = content + " ->REPLIES-> " + replies
+            replies = ". ".join([n["content"] for n in note["replies"]])
+            content = content + ". " + replies
         result[note["category"]["name"]] += content
     return result
 

--- a/openpype/pipeline/delivery.py
+++ b/openpype/pipeline/delivery.py
@@ -119,7 +119,8 @@ def deliver_single_file(
     anatomy_data,
     format_dict,
     report_items,
-    log
+    log,
+    test_run = False,
 ):
     """Copy single file to calculated path based on template
 
@@ -162,8 +163,9 @@ def deliver_single_file(
     if not os.path.exists(delivery_folder):
         os.makedirs(delivery_folder)
 
-    log.debug("Copying single: {} -> {}".format(src_path, delivery_path))
-    _copy_file(src_path, delivery_path)
+    if not test_run:
+        log.debug("Copying single: {} -> {}".format(src_path, delivery_path))
+        _copy_file(src_path, delivery_path)
 
     # TODO: use defaultdict instead?
     if not "created_files" in report_items:
@@ -181,7 +183,8 @@ def deliver_sequence(
     anatomy_data,
     format_dict,
     report_items,
-    log
+    log,
+    test_run = False,
 ):
     """ For Pype2(mainly - works in 3 too) where representation might not
         contain files.
@@ -314,8 +317,9 @@ def deliver_sequence(
 
         dst_padding = dst_collection.format("{padding}") % index
         dst = "{}{}{}".format(dst_head, dst_padding, dst_tail)
-        log.debug("Copying single: {} -> {}".format(src, dst))
-        _copy_file(src, dst)
+        if not test_run:
+            log.debug("Copying single: {} -> {}".format(src, dst))
+            _copy_file(src, dst)
         uploaded += 1
         report_items["created_files"].append(dst)
 

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -204,36 +204,82 @@
             "create_client_review_default": false,
             "csv_template_families":
             {
-                "elements": [
+                "elements":[
                     {
-                        "column_name": "End Frame",
-                        "column_value": "{asset_data[end]}"
+                        "column_name": "EXR Delivery Date",
+                        "column_value": "{mm}/{dd}/{yyyy}"
                     },
                     {
-                        "column_name": "Duration",
-                        "column_value": "{asset_data[duration]}"
-                    }
-            ],
-                "dailies": [
-                    {
-                        "column_name": "Shot - Asset",
-                        "column_value": "{asset}"
+                        "column_name": "Version Name",
+                        "column_value": "{asset}_{task[name]}_{subset}_v{version:0>4}"
                     },
                     {
-                        "column_name": "Task",
-                        "column_value": "{task[name]}"
-                    }
-            ],
-                "finals_": [
-                    {
-                        "column_name": "Date",
-                        "column_value": "{yyyy} - {mm} - {dd}"
+                        "column_name": "Shot Name",
+                        "column_value": "{shot_name}"
                     },
                     {
-                        "column_name": "File Name",
-                        "column_value": "{asset}_{subset}_v{version:0>4}<_{output}><.{frame:0>4}>.{ext}"
+                        "column_name": "Status",
+                        "column_value": "{status}"
+                    },
+                    {
+                        "column_name": "Shot > Status",
+                        "column_value": "{shot[status]}"
+                    },
+                    {
+                        "column_name": "Submission ID",
+                        "column_value": "{submission_name}"
+                    },
+                    {
+                        "column_name": "EXR Includes Mattes",
+                        "column_value": "{exr_includes_mattes}"
+                    },
+                    {
+                        "column_name": "For Client Notes",
+                        "column_value": "{notes[For Client]}"
+                    },
+                    {
+                        "column_name": "Client Feedback Notes",
+                        "column_value": "{notes[Client Feedback]}"
                     }
-            ],
+                ],
+                "dailies":[
+                    {
+                        "column_name": "EXR Delivery Date",
+                        "column_value": "{mm}/{dd}/{yyyy}"
+                    },
+                    {
+                        "column_name": "Version Name",
+                        "column_value": "{asset}_{task[name]}_{subset}_v{version:0>4}"
+                    },
+                    {
+                        "column_name": "Shot Name",
+                        "column_value": "{shot_name}"
+                    },
+                    {
+                        "column_name": "Status",
+                        "column_value": "{status}"
+                    },
+                    {
+                        "column_name": "Shot > Status",
+                        "column_value": "{shot[status]}"
+                    },
+                    {
+                        "column_name": "Submission ID",
+                        "column_value": "{submission_name}"
+                    },
+                    {
+                        "column_name": "EXR Includes Mattes",
+                        "column_value": "{exr_includes_mattes}"
+                    },
+                    {
+                        "column_name": "For Client Notes",
+                        "column_value": "{notes[For Client]}"
+                    },
+                    {
+                        "column_name": "Client Feedback Notes",
+                        "column_value": "{notes[Client Feedback]}"
+                    }
+                ],
                 "finals":[
                     {
                         "column_name": "EXR Delivery Date",
@@ -270,10 +316,6 @@
                     {
                         "column_name": "Client Feedback Notes",
                         "column_value": "{notes[Client Feedback]}"
-                    },
-                    {
-                        "column_name": "Missing Notes",
-                        "column_value": "{notes[False Tag]}"
                     }
                 ],
                 "fallback": [

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -202,64 +202,139 @@
             ],
             "delivery_templates": {},
             "create_client_review_default": false,
-            "delivery_csv_items": [
-                {
-                    "column_name": "Studio",
-                    "column_value": "22Dogs"
-                },
-                {
-                    "column_name": "Shot - Asset",
-                    "column_value": "{asset}"
-                },
-                {
-                    "column_name": "Task",
-                    "column_value": "{task[name]}"
-                },
-                {
-                    "column_name": "Episode",
-                    "column_value": "{episode_name}"
-                },
-                {
-                    "column_name": "Sequence",
-                    "column_value": "{sequence_name}"
-                },
-                {
-                    "column_name": "Asset",
-                    "column_value": "{asset_name}"
-                },
-                {
-                    "column_name": "Date",
-                    "column_value": "{yyyy} - {mm} - {dd}"
-                },
-                {
-                    "column_name": "File Name",
-                    "column_value": "{asset}_{subset}_v{version:0>4}<_{output}><.{frame:0>4}>.{ext}"
-                },
-                {
-                    "column_name": "Format",
-                    "column_value": "{ext}"
-                },
-                {
-                    "column_name": "Family",
-                    "column_value": "{family}"
-                },
-                {
-                    "column_name": "Subset",
-                    "column_value": "{subset}"
-                },
-                {
-                    "column_name": "Start Frame",
-                    "column_value": "{asset_data[start]}"
-                },
-                {
-                    "column_name": "End Frame",
-                    "column_value": "{asset_data[end]}"
-                },
-                {
-                    "column_name": "Duration",
-                    "column_value": "{asset_data[duration]}"
-                }
-            ]
+            "csv_template_families":
+            {
+                "elements": [
+                    {
+                        "column_name": "End Frame",
+                        "column_value": "{asset_data[end]}"
+                    },
+                    {
+                        "column_name": "Duration",
+                        "column_value": "{asset_data[duration]}"
+                    }
+            ],
+                "dailies": [
+                    {
+                        "column_name": "Shot - Asset",
+                        "column_value": "{asset}"
+                    },
+                    {
+                        "column_name": "Task",
+                        "column_value": "{task[name]}"
+                    }
+            ],
+                "finals_": [
+                    {
+                        "column_name": "Date",
+                        "column_value": "{yyyy} - {mm} - {dd}"
+                    },
+                    {
+                        "column_name": "File Name",
+                        "column_value": "{asset}_{subset}_v{version:0>4}<_{output}><.{frame:0>4}>.{ext}"
+                    }
+            ],
+                "finals":[
+                    {
+                        "column_name": "EXR Delivery Date",
+                        "column_value": "{mm}/{dd}/{yyyy}"
+                    },
+                    {
+                        "column_name": "Version Name",
+                        "column_value": "{asset}_{task[name]}_{subset}_v{version:0>4}"
+                    },
+                    {
+                        "column_name": "Shot Name",
+                        "column_value": "{shot_name}"
+                    },
+                    {
+                        "column_name": "Status",
+                        "column_value": "{status}"
+                    },
+                    {
+                        "column_name": "Shot > Status",
+                        "column_value": "{shot[status]}"
+                    },
+                    {
+                        "column_name": "Submission ID",
+                        "column_value": "{submission_name}"
+                    },
+                    {
+                        "column_name": "EXR Includes Mattes",
+                        "column_value": "{exr_includes_mattes}"
+                    },
+                    {
+                        "column_name": "For Client Notes",
+                        "column_value": "{notes[For Client]}"
+                    },
+                    {
+                        "column_name": "Client Feedback Notes",
+                        "column_value": "{notes[Client Feedback]}"
+                    },
+                    {
+                        "column_name": "Missing Notes",
+                        "column_value": "{notes[False Tag]}"
+                    }
+                ],
+                "fallback": [
+                    {
+                        "column_name": "Studio",
+                        "column_value": "22Dogs"
+                    },
+                    {
+                        "column_name": "Shot - Asset",
+                        "column_value": "{asset}"
+                    },
+                    {
+                        "column_name": "Task",
+                        "column_value": "{task[name]}"
+                    },
+                    {
+                        "column_name": "Episode",
+                        "column_value": "{episode_name}"
+                    },
+                    {
+                        "column_name": "Sequence",
+                        "column_value": "{sequence_name}"
+                    },
+                    {
+                        "column_name": "Asset",
+                        "column_value": "{asset_name}"
+                    },
+                    {
+                        "column_name": "Date",
+                        "column_value": "{yyyy} - {mm} - {dd}"
+                    },
+                    {
+                        "column_name": "File Name",
+                        "column_value": "{asset}_{subset}_v{version:0>4}<_{output}><.{frame:0>4}>.{ext}"
+                    },
+                    {
+                        "column_name": "Format",
+                        "column_value": "{ext}"
+                    },
+                    {
+                        "column_name": "Family",
+                        "column_value": "{family}"
+                    },
+                    {
+                        "column_name": "Subset",
+                        "column_value": "{subset}"
+                    },
+                    {
+                        "column_name": "Start Frame",
+                        "column_value": "{asset_data[start]}"
+                    },
+                    {
+                        "column_name": "End Frame",
+                        "column_value": "{asset_data[end]}"
+                    },
+                    {
+                        "column_name": "Duration",
+                        "column_value": "{asset_data[duration]}"
+                    }
+                ]
+            }
         },
         "gather_action": {
             "enabled": true,

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -216,6 +216,18 @@
                     "column_value": "{task[name]}"
                 },
                 {
+                    "column_name": "Episode",
+                    "column_value": "{episode_name}"
+                },
+                {
+                    "column_name": "Sequence",
+                    "column_value": "{sequence_name}"
+                },
+                {
+                    "column_name": "Asset",
+                    "column_value": "{asset_name}"
+                },
+                {
                     "column_name": "Date",
                     "column_value": "{yyyy} - {mm} - {dd}"
                 },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -666,27 +666,31 @@
                             "label": "Ftrack's Action default value for create client review (will have same name as delivery list)"
                         },
                         {
-                            "type": "list",
+                            "label":"CSV Template Families",
+                            "key":"csv_template_families",
+                            "type":"dict-modifiable",
                             "collapsible": true,
-                            "key": "delivery_csv_items",
-                            "label": "Delivery CSV Items",
                             "use_label_wrap": true,
-                            "object_type": {
-                                "type": "dict",
-                                "children": [
-                                    {
-                                        "key": "column_name",
-                                        "label": "Column name",
-                                        "type": "text"
-                                    },
-                                    {
-                                        "key": "column_value",
-                                        "label": "Column value",
-                                        "type": "text"
-                                    }
-                                ]
+                            "object_type":{
+                                "type": "list",
+                                "collapsible": true,
+                                "object_type": {
+                                    "type": "dict",
+                                    "children": [
+                                        {
+                                            "key": "column_name",
+                                            "label": "Column name",
+                                            "type": "text"
+                                        },
+                                        {
+                                            "key": "column_value",
+                                            "label": "Column value",
+                                            "type": "text"
+                                        }
+                                    ]
+                                }
                             }
-                        }
+                    }
                     ]
                 },
                 {


### PR DESCRIPTION
## Brief description
Adding small tweaks to the delivery action as requested by Production

## Description
1. Removing output, extension and frames in `delivered_name` attribute from the assetversions
2. Fixing the delivery path so it points to the root of the delivery now, instead of getting the minimum common folder of the delivered items
3. If a csv key is missing it will put an empty string instead of failing
4. Having csv go in the right location, if there is no list name for the template of the delivery it is saved in longest common root of the delivered files
5. added episode_name, sequence_name and asset_name keys
6. adding Episode, Sequence and Asset column to default CSV
7. Making a FtrackUI option so that the CSV can be launch alone
8. Adding more fields: comments, episode, sequence, shot, asset, submission name, status, shot>status
9. Saving CSV in downloads if it is not list, instead of saving it in temp folder
10. Making the CSV config options so there can be more than one config per project (like it happens with delivery templates "finals", "dailies", etc)
11. Adding ordering for versions, user can select to order alphabeticallly (default) or by verison number
12. Adding a feedback error when no components are selected from the dialog and there are no representations found.