### PR TITLE
Making intermediate-usd-in-farm optional

### DIFF
--- a/openpype/hosts/houdini/plugins/create/create_usdrender.py
+++ b/openpype/hosts/houdini/plugins/create/create_usdrender.py
@@ -41,6 +41,7 @@ class CreateUSDRender(plugin.HoudiniCreator):
 
         # Add Deadline Parameters to Create USD Render ROP
         extra_parms = {
+            "intermediate_to_farm": False,
             "suspendPublishJob": False,
             "review": True,
             "multipartExr": True,

--- a/openpype/version.py
+++ b/openpype/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """Package declaring Pype version."""
-__version__ = "3.14.11-22dogs.64"
+__version__ = "3.14.11-22dogs.63"
 # __version__ = "3.14.11-22dogs.71+staging"


### PR DESCRIPTION
## Brief description
As the USD intermediate in farm needs more debug, we have created this as an opt-in bool, by default is `false`, so it does not interfiere with the natural course of our _warmly regarded and beloved_ artists.

## Details
1. Added a OUT/Extra option called `intermediate_to_farm` which decides whether the intermediate is localy created or in farm
2. Fixing the USD file location so that now it goes to the right folder
3. Removing some `pprint` code and adding some shy docstrings.
4. Getting the version back to 63 as in 64 I was getting the staging config

## Testing notes
1. As in 63 there is no ttd_hou_utils, we would need to bump this version up so OP can find this library in `app_repos`.
2. In `TEST_OP_NEW` there is an asset/character called Serdito, the Modeling task has a workfile prepared for this testing.
4. There may be some issues in case the Houdini Version submitted is 19-5-805-Core instead of 19-5-Core.