### PR TITLE
Fixing deadline empty dependency bug in the intermediate USD creation AND adding better user feedback when all selected AssetVersions have been already gathered

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_houdini_usd_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_usd_render_deadline.py
@@ -349,11 +349,10 @@ class houdiniSubmitUSDRenderDeadline(pyblish.api.InstancePlugin):
         if self.intermediate_to_farm:
             resp = self.submit(instance, intermediate_payload)
             dependency = resp.json()["_id"]
+            payload["JobInfo"]["JobDependencies"] = [dependency]
         else:
-            dependency = ""
             create_intermediate_usd(ropnode, hou_usd_path)
 
-        payload["JobInfo"]["JobDependencies"] = [dependency]
         response = self.submit(instance, payload)
 
 

--- a/openpype/modules/ftrack/event_handlers_user/action_gather.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_gather.py
@@ -130,6 +130,12 @@ class GatherAction(BaseAction):
             instance_data = self.publisher_start(session, version, user_values)
             forwarding_data.append(instance_data)
 
+        if not forwarding_data:
+            return {
+                "success": True,
+                "message": "All assets already had linked versions and they were skipped."
+            }
+
         exchange_file = tempfile.mktemp(prefix="traypublisher_gather_", suffix=".json")
         with open(exchange_file, "w") as exf:
             exf.write(json.dumps(forwarding_data, indent=4, default=str))

--- a/openpype/modules/ftrack/event_handlers_user/action_gather.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_gather.py
@@ -133,7 +133,7 @@ class GatherAction(BaseAction):
         if not forwarding_data:
             return {
                 "success": True,
-                "message": "All assets already had linked versions and they were skipped."
+                "message": "All AssetVersions were already gathered. The action was kipped."
             }
 
         exchange_file = tempfile.mktemp(prefix="traypublisher_gather_", suffix=".json")


### PR DESCRIPTION
## Brief description
1. If all AssetVersions where already gathered, the list `forwarding_data` is empty, and the json ends up being an empty list, which in turn it throws a list `IndexError` when the traypublisher attempts to read data from the empty list.
2. Matteo reported the USD intermediate creation having an empty dependency when the intermediate was not sent to the farm. This fixes it.