### PR TITLE
Adding filter by asset name to version status -> status

### DIFF
--- a/openpype/modules/ftrack/event_handlers_server/event_version_to_task_statuses.py
+++ b/openpype/modules/ftrack/event_handlers_server/event_version_to_task_statuses.py
@@ -1,4 +1,4 @@
-from openpype_modules.ftrack.lib import BaseEvent
+from openpype_modules.ftrack.lib import BaseEvent # type: ignore
 
 
 class VersionToTaskStatus(BaseEvent):
@@ -77,6 +77,9 @@ class VersionToTaskStatus(BaseEvent):
             for short_name in event_settings["asset_types_to_skip"]
         ]
 
+
+        prefixes_to_skip = [tag for tag in event_settings.get("asset_prefix_to_skip", [])]
+
         # Collect entity ids
         asset_version_ids = set()
         for entity_info in entities_info:
@@ -99,6 +102,12 @@ class VersionToTaskStatus(BaseEvent):
                 short_name = asset_version["asset"]["type"]["short"].lower()
                 if short_name in asset_types_to_skip:
                     continue
+
+            if prefixes_to_skip:
+                asset_name = asset_version["asset"]["name"]
+                if any(asset_name.startswith(tag) for tag in prefixes_to_skip):
+                    continue
+
             asset_version_entities.append(asset_version)
             task_ids.add(asset_version["task_id"])
 

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -96,7 +96,7 @@
             "enabled": true,
             "mapping": {},
             "asset_types_to_skip": [],
-            "asset_prefix_to_skip": ["prerender", "preRender"]
+            "asset_prefix_to_skip": ["prerender"]
         },
         "next_task_update": {
             "enabled": true,

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -95,7 +95,8 @@
         "status_version_to_task": {
             "enabled": true,
             "mapping": {},
-            "asset_types_to_skip": []
+            "asset_types_to_skip": [],
+            "asset_prefix_to_skip": ["prerender", "preRender"]
         },
         "next_task_update": {
             "enabled": true,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -302,6 +302,16 @@
                             "label": "Asset types (short)",
                             "key": "asset_types_to_skip",
                             "object_type": "text"
+                        },
+                        {
+                            "type": "label",
+                            "label": "<b>Disable<b/> event if status was changed on specific asset name with a prefix."
+                        },
+                        {
+                            "type": "list",
+                            "label": "Prefix",
+                            "key": "asset_prefix_to_skip",
+                            "object_type": "text"
                         }
                     ]
                 },


### PR DESCRIPTION
## Brief description
This PR comes from the issue that when publishing a prerender, it now goes into Ftrack and OP updates the Compositing task status task automaticaly mayching the prerender one, which is a bug, as prerender is not to be reviewed.

## Description
The OP server action that transfer the version status into the task status has only one way of filtering: by asset type.
Because both `prerender` and `render` use the Ftrack type `Render`, this is not enough to prevent prerender to update the compositing task, and thus this PR presents a modification of the action so that it can also filter by asset name prefix.

This PR adds OpenPype setting `asset_prefix_to_skip` to the `openpype/modules/ftrack/event_handlers_server/event_version_to_task_statuses.py` action.

![image](https://github.com/maxpareschi/OpenPype/assets/166030421/390492b2-a1a9-4a41-8719-376b63ed74c8)

