### PR TITLE
fixing a bug in delete_action and another in gather_action

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_gather.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_gather.py
@@ -173,7 +173,10 @@ class GatherAction(BaseAction):
             files.append(file["path"].format(**repre["context"]))
         version_start = int(version["data"]["frameStart"]) - int(version["data"]["handleStart"])
         basename = str(os.path.splitext(files[0])[0])
-        detected_startframe = re.findall(r'\d+$', basename)
+
+        # the regex below has to account for cases such as v0010_dnxhd
+        detected_startframe = re.findall(r'\d+(?=[A-Za-z\_]*$)', basename)
+
         str_index = basename.find(detected_startframe[0])
         if basename[str_index-1] == "v":
             detected_startframe = None

--- a/openpype/modules/ftrack/event_handlers_user/action_ttd_delete_version.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_ttd_delete_version.py
@@ -207,7 +207,6 @@ class DeleteVersionAction(BaseAction):
     def launch(self, session: Session, entities: List[Entity], event: Event):
         # from pprint import pprint
         self.versions = self.versions or self._extract_asset_versions(session, entities)
-
         if not event["data"].get("values", {}):
             return {
                 "type": "form",
@@ -216,6 +215,7 @@ class DeleteVersionAction(BaseAction):
                 "submit_button_label": "I know what I'm doing. <b>Remove permanently.</b>"
             }
 
+        session = Session()
         for entity in self.versions:
             self.log.info(f"Working on version {entity['asset']['name']}")
             in_links = list(entity["incoming_links"])


### PR DESCRIPTION
## Brief description
1. `openpype/modules/ftrack/event_handlers_user/action_gather.py`: fixed `IndexError` as old regex failed to find a match with items that had trailing string after version token, such as `v0010_dnxhd`. Now it matches both `v0010$` and `v0010_dnxhd$`.
2. `openpype/modules/ftrack/event_handlers_user/action_ttd_delete_version.py`: fixing a bug that appeared if you tried to delete a version after having executed a traypublisher gather, it would throw a `ftrack_api.exception.ServerERROR` (details below), even though attempting to delete the same version for a second time it would succeed; furthermore, if the OP was restarted after having finished the gather action, this error wouldn't appear. By creating a new Ftrack Session specific for the deletion of the `AssetVersions`, this error is prevented.

## Fixed traceback error (for the record)
```
Traceback (most recent call last):
  File "C:\Users\22Dogs\Documents\repositories\OpenPype\openpype\modules\ftrack\lib\ftrack_base_handler.py", line 137, in wrapper_launch
    return func(*args, **kwargs)
  File "C:\Users\22Dogs\Documents\repositories\OpenPype\openpype\modules\ftrack\event_handlers_user\action_ttd_delete_version.py", line 257, in launch
    session.commit()
  File "C:\Users\22Dogs\Documents\repositories\OpenPype\venv\lib\site-packages\ftrack_api\session.py", line 1308, in commit
    result = self.call(batch)
  File "C:\Users\22Dogs\Documents\repositories\OpenPype\venv\lib\site-packages\ftrack_api\session.py", line 1687, in call
    raise ftrack_api.exception.ServerERROR(ERROR_message)
ftrack_api.exception.ServerERROR: Server reported ERROR: DuplicateEntryERROR(Duplicate entry 092e0325-fb67-42ec-b828-4f37d29b4dc3-modeling for Context unique on parent_id, name.)
``` 
