### PR TITLE
Printing out an aprox. progress in Deadline OP publish process

### DIFF
--- a/openpype/pype_commands.py
+++ b/openpype/pype_commands.py
@@ -147,8 +147,12 @@ class PypeCommands:
             # Error exit as soon as any error occurs.
             error_format = ("Failed {plugin.__name__}: "
                             "{error} -- {error.traceback}")
-
+            n = 0
+            total = len(plugins)
             for result in pyblish.util.publish_iter():
+                n += 1
+                log.info(f"Running plugin {plugins[n].__name__}: ({n}/{total})")
+                log.info(f"[{plugins[n].__name__}] Progress: {int(100*n/total)}%")
                 if result["error"]:
                     log.error(error_format.format(**result))
                     # uninstall()


### PR DESCRIPTION
## Brief description
Enabling Deadline Monitor's progress bar for OpenPype publish in farm.

## Description
The easiest way to implement this is by printing out an aproximation progress for the OpenPype headless publish process so that the stdout can be parsed by the OpenPype deadline plugin so that it can update the GUI progress bar in Deadline Monitor.

## Testing notes:
1. As there is some delay between the capture of the stdout by the OpenPype Deadline plugin and as some Pyblish plugins are processed very fast, the progress bar in the Deadline Monitor GUI will be updated in chunks, and so far it seems to first being picked up at 56%, when the transcoding starts happening, because this plugin takes some more time to process and thus the GUI has time to catch up.
2. As some Pyblish plugins are ignored at runtime, and as there is no easy way to predict the real amount of processed plugins before hand, the progress bar range may finish earlier, at around 80% and from there there will be another hard jump to 100% in the Monitorr's progress bar.

## Screenshots
![image](https://github.com/user-attachments/assets/c2d07fd5-b883-42a1-9873-76656fe2eb16)
