### PR TITLE
reworking default values and values from settings

### DIFF
--- a/openpype/modules/deadline/plugins/publish/submit_houdini_usd_render_deadline.py
+++ b/openpype/modules/deadline/plugins/publish/submit_houdini_usd_render_deadline.py
@@ -40,18 +40,21 @@ class houdiniSubmitUSDRenderDeadline(pyblish.api.InstancePlugin):
     targets = ["local"]
 
     # presets
-    usd_intermediate_on_farm = True
-    flush_data_after_each_frame = True
-    suspendPublishJob = False
-    review =  True
-    multipartExr =  True
-    priority = 50
-    chunk_size = 1
-    concurrent_tasks = 1
-    group = ""
-    department = ""
-    primary_pool = ""
-    secondary_pool = ""
+    # NOTE: these defaults are not needed as the create_usdrender.py module
+    # already has defaults
+
+    # usd_intermediate_on_farm = True
+    # flush_data_after_each_frame = True
+    # suspendPublishJob = True
+    # review =  True
+    # multipartExr =  True
+    # priority = 50
+    # chunk_size = 1
+    # concurrent_tasks = 1
+    # group = ""
+    # department = ""
+    # primary_pool = ""
+    # secondary_pool = ""
 
     # TODO Implement other deadline stuff
     # limit_groups = {}


### PR DESCRIPTION
## Brief description
Rework on how the attributes of the USD Render are handled

## Description
As the `create_usdrender.py` module already has defaults, there seems to be no need for having defaults in the `submit_usd_render_deadline.py` module. I comented out these defaults in case there is any other reason why they are there, but everything seems to work fine without them.

As there are some project settings regarding houdini and deadline, I have hooked them up to the defaults so that we can change things like priorities, pools, groups etc on the settings.

I have also added the department default to be the same as the task name, this was a request by Matteo Musci.

The GUI options were not loading defaults because the keyword argument `default` was not being used, instead the value was being passed as a positional argument which ended up being hoked up with the `multiline` positional argument. Details in the picture below:

![image](https://github.com/user-attachments/assets/18031614-e976-4296-b8b9-5be366f343d3)
