### PR TITLE
fixing bug in the create_list function

### DIFF
--- a/openpype/modules/ftrack/lib/ftrack_shared_funcs.py
+++ b/openpype/modules/ftrack/lib/ftrack_shared_funcs.py
@@ -203,8 +203,8 @@ def create_list(session: Session,
         list_category_name
     )).first() or None
 
-    review_session_folder = session.query("ReviewSessionFolder where name is '{}'".format(
-        list_category_name
+    review_session_folder = session.query("ReviewSessionFolder where name is '{}' and project.id is {}".format(
+        list_category_name, entities[0]["project"]["id"]
     )).first() or None
 
     list_owner = session.query("User where id is '{}'".format(


### PR DESCRIPTION
## Brief description
Running the action "Create Delivered List" and selecting the "Create ReviewSession" option was causing a bug in the Ftrack Web App where the CIien Review dropdown was failing to show its contents.

## Description
The `create_list` function creates either `List` or `ReviewSession`. If the `ListCategory` or `ReviewSession` existed, the function will not create those entities, but if they were missing it would create them. The function queried for an already existing `ReviewSessionFolder` *without specifying the project*, and the query was returning a `ReviewSessionFolder` from another project different from that project of the `ReviewSession` that was being created. After adding the project id to the query, this error ceased to occur.
The Ftrack Web App was bugging because it was trying to display a `ReviewSession` whose `ReviewSessionFolder` belonged to a different `Project`.
We introduced this bug because `ListCategories` don't have project and unaware we extended this logic to the `ReviewSessionFolder`, which was not the case.