### PR TITLE
better delivery error handling

### DIFF
--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -296,7 +296,11 @@ def handle_csv(
     if order == "version":
         repres = sorted(repres, key=by_version)
 
-    csv_file = get_csv_path(report["created_files"], name)
+    try:
+        csv_file = get_csv_path(report["created_files"], name)
+    except IndexError as e:
+        raise NotADirectoryError(report) from e
+
     if csv_file is not None:
         generate_csv_from_representations(prj, repres, csv_file, cfg)
         logger.info(f"CSV saved in {csv_file}")

--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -299,7 +299,7 @@ def handle_csv(
     try:
         csv_file = get_csv_path(report["created_files"], name)
     except IndexError as e:
-        raise NotADirectoryError(report) from e
+        raise NotImplementedError(report) from e
 
     if csv_file is not None:
         generate_csv_from_representations(prj, repres, csv_file, cfg)

--- a/openpype/modules/ftrack/event_handlers_user/action_delivery.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_delivery.py
@@ -68,7 +68,8 @@ class Delivery(BaseAction):
         create_review_default = self.action_settings["create_client_review_default"]
 
         title = "Delivery data to Client"
-
+        settings = self.get_ftrack_settings(session, event, entities)["user_handlers"]
+        template_name = settings["create_derived_list_action"]["review_session_template_name"]
         items = []
 
         project_entity = self.get_project_from_entity(entities[0])
@@ -233,17 +234,25 @@ class Delivery(BaseAction):
             "type": "enumerator",
             "name": "order",
             "data": [
-            {
-                'label': 'alphabetically',
-                'value': 'alphabetically'
-            }, {
-                'label': 'version',
-                'value': 'version'
-            }
-        ],
+                {
+                    'label': 'alphabetically',
+                    'value': 'alphabetically'
+                }, {
+                    'label': 'version',
+                    'value': 'version'
+                }
+            ],
             "label": "Order of the versions in the CSV.",
             "value": "alphabetically"
-        })
+            })
+        
+        items.append(
+            {
+            "label": "Review Template Name",
+            "type": "text",
+            "name": "template_name",
+            "value": template_name,
+                })
 
         return {
             "items": items,
@@ -681,6 +690,7 @@ class Delivery(BaseAction):
         # up template values
         ftrack_list_name = None
         ftrack_list_category_name = None
+        
         if entities[0].entity_type == "AssetVersionList":
             ftrack_list_name = entities[0]["name"]
             ftrack_list_category_name = entities[0]["category"]["name"]
@@ -908,6 +918,7 @@ class Delivery(BaseAction):
                 entities,
                 event,
                 client_review = values["create_review_session"],
+                template_name = values["template_name"],
                 list_name = ftrack_list_name,
                 list_category_name = entities[0]["category"]["name"],
                 log = self.log


### PR DESCRIPTION
## Brief description
When a key in a delivery template was missing, there was no feedback stating where the error came from, now it is displayed in the Ftrack Web app.
Adding also the chance to create the Client Review from template in the Delivery Action (it was formerly available only in the Create Delivered List action)

Also added detection of mattes via looking at the alpha channels for the csv