### PR TITLE
Implementing incremental autosave for nuke 

### DIFF
--- a/openpype/hosts/nuke/api/__init__.py
+++ b/openpype/hosts/nuke/api/__init__.py
@@ -37,6 +37,7 @@ from .utils import (
     get_colorspace_list
 )
 
+from . import autosave
 __all__ = (
     "file_extensions",
     "has_unsaved_changes",
@@ -66,5 +67,6 @@ __all__ = (
     "convert_knob_value_to_correct_type",
 
     "colorspace_exists_on_node",
-    "get_colorspace_list"
+    "get_colorspace_list",
+    "autosave",
 )

--- a/openpype/hosts/nuke/api/autosave.py
+++ b/openpype/hosts/nuke/api/autosave.py
@@ -1,6 +1,7 @@
 import glob
 import time
 import os
+from pprint import pformat
 from openpype.lib import Logger
 
 import nuke
@@ -17,95 +18,97 @@ logger = Logger.get_logger(__name__)
 settings = get_current_project_settings()["nuke"]["general"]["autosave"]
 increments = settings["increments"]
 
-def onAutoSave(filename):
+def on_autosave(filename):
 
-  ## ignore untiled autosave
-  if nuke.root().name() == 'Root':
-    return filename
+    ## ignore untiled autosave
+    if nuke.root().name() == 'Root':
+        return filename
 
-  fileNo = 0
-  files = getAutoSaveFiles(filename)
-
-  if len(files) > 0 :
-    lastFile = files[-1]
-    # get the last file number
-
-    if len(lastFile) > 0:
-      try:
-        fileNo = int(lastFile[-1:])
-      except:
-        pass
-
-      fileNo = fileNo + 1
-
-  if ( fileNo > increments ):
     fileNo = 0
+    files = get_autosave_files(filename)
 
-  if ( fileNo != 0 ):
+    if len(files) > 0 :
+        lastFile = files[-1]
+        # get the last file number
+
+        if len(lastFile) > 0:
+            try:
+                fileNo = int(lastFile[-1:])
+            except:
+                pass
+
+            fileNo = fileNo + 1
+
+    if ( fileNo > increments ):
+        fileNo = 0
+
+    # if ( fileNo != 0 ):
     filename = filename + str(fileNo)
 
-  return filename
-
-
-def onAutoSaveRestore(filename):
-
-  files = getAutoSaveFiles(filename)
-
-  if len(files) > 0:
-    filename = files[-1]
-
-  return filename
-
-def onAutoSaveDelete(filename):
-
-  ## only delete untiled autosave
-  if nuke.root().name() == 'Root':
+    logger.info(f"Autosaving file: {filename}")
     return filename
 
-  # return None here to not delete auto save file
-  return None
+def on_autosave_restore(filename):
+    """To allow to read from not just autosave (default) but also autosave1, 2, 3..."""
 
-  
-def getAutoSaveFiles(filename):
-  date_file_list = []
-  files = glob.glob(filename + f'[1-{increments}]')
-  files.extend( glob.glob(filename) )
+    files = get_autosave_files(filename)
 
-  for file in files:
-      # retrieves the stats for the current file as a tuple
-      # (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime)
-      # the tuple element mtime at index 8 is the last-modified-date
-      stats = os.stat(file)
-      # create tuple (year yyyy, month(1-12), day(1-31), hour(0-23), minute(0-59), second(0-59),
-      # weekday(0-6, 0 is monday), Julian day(1-366), daylight flag(-1,0 or 1)) from seconds since epoch
-      # note:  this tuple can be sorted properly by date and time
-      lastmod_date = time.localtime(stats[8])
-      #print image_file, lastmod_date   # test
-      # create list of tuples ready for sorting by date
-      date_file_tuple = lastmod_date, file
-      date_file_list.append(date_file_tuple)
-   
-  date_file_list.sort()
-  return [ filename for _, filename in date_file_list ]
+    if len(files) > 0:
+        filename = files[-1]
 
+    logger.info(f"Restoring autosave file: {filename}")
+    return filename
+
+def on_autosave_delete(filename):
+
+    ## only delete untiled autosave
+    if nuke.root().name() == 'Root':
+        return filename
+
+    # return None here to not delete auto save file
+    return None
+    
+def get_autosave_files(filename):
+    date_file_list = []
+    files = glob.glob(filename + f'*autosave[0-{increments}]')
+
+    for file in files:
+        logger.debug(file)
+        # retrieves the stats for the current file as a tuple
+        # (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime)
+        # the tuple element mtime at index 8 is the last-modified-date
+        stats = os.stat(file)
+        # create tuple (year yyyy, month(1-12), day(1-31), hour(0-23), minute(0-59), second(0-59),
+        # weekday(0-6, 0 is monday), Julian day(1-366), daylight flag(-1,0 or 1)) from seconds since epoch
+        # note:    this tuple can be sorted properly by date and time
+        lastmod_date = time.localtime(stats[8])
+        #print image_file, lastmod_date     # test
+        # create list of tuples ready for sorting by date
+        date_file_tuple = lastmod_date, file
+        date_file_list.append(date_file_tuple)
+     
+    date_file_list.sort()
+    autosaves = [ filename for _, filename in date_file_list ]
+    logger.info(f"Found following autosaves {pformat(autosaves)}")
+    return autosaves
 
 
 ### As an example to remove the callbacks use this code
-#nuke.removeAutoSaveFilter( onAutoSave )
-#nuke.removeAutoSaveRestoreFilter( onAutoSaveRestore )
-#nuke.removeAutoSaveDeleteFilter( onAutoSaveDelete )
+#nuke.removeAutoSaveFilter( on_autosave )
+#nuke.removeAutoSaveRestoreFilter( on_autosave_restore )
+#nuke.removeAutoSaveDeleteFilter( on_autosave_delete )
 
 def activate_incremental_autosave():
-  try:
-      nuke.addAutoSaveFilter( onAutoSave )
-      nuke.addAutoSaveRestoreFilter( onAutoSaveRestore )
-      nuke.addAutoSaveDeleteFilter( onAutoSaveDelete )
-  except Exception as e:
-      logger.warning(f"Failed to activate incremental autosave: {e}")
-  else:
-      logger.info(f"Autosave activated successfully")
+    try:
+            nuke.addAutoSaveFilter( on_autosave )
+            # nuke.addAutoSaveRestoreFilter( on_autosave_restore )
+            nuke.addAutoSaveDeleteFilter( on_autosave_delete )
+    except Exception as e:
+            logger.warning(f"Failed to activate incremental autosave: {e}")
+    else:
+            logger.info(f"Autosave activated successfully")
 
 if settings["enabled"] and settings["increments"] > 0:
-  activate_incremental_autosave()
+    activate_incremental_autosave()
 else:
-  logger.info(f"Incremental autosave for this project is disabled")
+    logger.info(f"Incremental autosave for this project is disabled")

--- a/openpype/hosts/nuke/api/autosave.py
+++ b/openpype/hosts/nuke/api/autosave.py
@@ -14,9 +14,10 @@ logger = Logger.get_logger(__name__)
 ## autosaves roll from 0-9 eg myfile.autosave, myfile.autosave1, myfile.autosave2...
 #
 ## To use just add 'import nukescripts.autosave' in your init.py
+settings = get_current_project_settings()["nuke"]["general"]["autosave"]
+increments = settings["increments"]
 
-
-def onAutoSave(filename, increments):
+def onAutoSave(filename):
 
   ## ignore untiled autosave
   if nuke.root().name() == 'Root':
@@ -65,7 +66,7 @@ def onAutoSaveDelete(filename):
   return None
 
   
-def getAutoSaveFiles(filename, increments):
+def getAutoSaveFiles(filename):
   date_file_list = []
   files = glob.glob(filename + f'[1-{increments}]')
   files.extend( glob.glob(filename) )
@@ -94,9 +95,9 @@ def getAutoSaveFiles(filename, increments):
 #nuke.removeAutoSaveRestoreFilter( onAutoSaveRestore )
 #nuke.removeAutoSaveDeleteFilter( onAutoSaveDelete )
 
-def activate_incremental_autosave(increments):
+def activate_incremental_autosave():
   try:
-      nuke.addAutoSaveFilter( onAutoSave, increments )
+      nuke.addAutoSaveFilter( onAutoSave )
       nuke.addAutoSaveRestoreFilter( onAutoSaveRestore )
       nuke.addAutoSaveDeleteFilter( onAutoSaveDelete )
   except Exception as e:
@@ -104,8 +105,7 @@ def activate_incremental_autosave(increments):
   else:
       logger.info(f"Autosave activated successfully")
 
-settings = get_current_project_settings()["nuke"]["general"]["autosave"]
 if settings["enabled"] and settings["increments"] > 0:
-  activate_incremental_autosave(settings["increments"])
+  activate_incremental_autosave()
 else:
   logger.info(f"Incremental autosave for this project is disabled")

--- a/openpype/hosts/nuke/api/autosave.py
+++ b/openpype/hosts/nuke/api/autosave.py
@@ -1,0 +1,111 @@
+import glob
+import time
+import os
+from openpype.lib import Logger
+
+import nuke
+
+from openpype.settings import get_current_project_settings
+
+logger = Logger.get_logger(__name__)
+
+### Example that implements a rolling autosave using the autoSaveFilter callbacks
+###
+## autosaves roll from 0-9 eg myfile.autosave, myfile.autosave1, myfile.autosave2...
+#
+## To use just add 'import nukescripts.autosave' in your init.py
+
+
+def onAutoSave(filename, increments):
+
+  ## ignore untiled autosave
+  if nuke.root().name() == 'Root':
+    return filename
+
+  fileNo = 0
+  files = getAutoSaveFiles(filename)
+
+  if len(files) > 0 :
+    lastFile = files[-1]
+    # get the last file number
+
+    if len(lastFile) > 0:
+      try:
+        fileNo = int(lastFile[-1:])
+      except:
+        pass
+
+      fileNo = fileNo + 1
+
+  if ( fileNo > increments ):
+    fileNo = 0
+
+  if ( fileNo != 0 ):
+    filename = filename + str(fileNo)
+
+  return filename
+
+
+def onAutoSaveRestore(filename):
+
+  files = getAutoSaveFiles(filename)
+
+  if len(files) > 0:
+    filename = files[-1]
+
+  return filename
+
+def onAutoSaveDelete(filename):
+
+  ## only delete untiled autosave
+  if nuke.root().name() == 'Root':
+    return filename
+
+  # return None here to not delete auto save file
+  return None
+
+  
+def getAutoSaveFiles(filename, increments):
+  date_file_list = []
+  files = glob.glob(filename + f'[1-{increments}]')
+  files.extend( glob.glob(filename) )
+
+  for file in files:
+      # retrieves the stats for the current file as a tuple
+      # (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime)
+      # the tuple element mtime at index 8 is the last-modified-date
+      stats = os.stat(file)
+      # create tuple (year yyyy, month(1-12), day(1-31), hour(0-23), minute(0-59), second(0-59),
+      # weekday(0-6, 0 is monday), Julian day(1-366), daylight flag(-1,0 or 1)) from seconds since epoch
+      # note:  this tuple can be sorted properly by date and time
+      lastmod_date = time.localtime(stats[8])
+      #print image_file, lastmod_date   # test
+      # create list of tuples ready for sorting by date
+      date_file_tuple = lastmod_date, file
+      date_file_list.append(date_file_tuple)
+   
+  date_file_list.sort()
+  return [ filename for _, filename in date_file_list ]
+
+
+
+### As an example to remove the callbacks use this code
+#nuke.removeAutoSaveFilter( onAutoSave )
+#nuke.removeAutoSaveRestoreFilter( onAutoSaveRestore )
+#nuke.removeAutoSaveDeleteFilter( onAutoSaveDelete )
+
+def activate_incremental_autosave(increments):
+  try:
+      nuke.addAutoSaveFilter( onAutoSave, increments )
+      nuke.addAutoSaveRestoreFilter( onAutoSaveRestore )
+      nuke.addAutoSaveDeleteFilter( onAutoSaveDelete )
+  except Exception as e:
+      logger.warning(f"Failed to activate incremental autosave: {e}")
+  else:
+      logger.info(f"Autosave activated successfully")
+
+settings = get_current_project_settings()["nuke"]["general"]["autosave"]
+if settings["enabled"] and settings["increments"] > 0:
+  activate_incremental_autosave(settings["increments"])
+else:
+  logger.info(f"Incremental autosave for this project is disabled")

--- a/openpype/hosts/nuke/api/workio.py
+++ b/openpype/hosts/nuke/api/workio.py
@@ -1,7 +1,23 @@
 """Host API required Work Files tool"""
 import os
 import nuke
+from pathlib import Path
+from datetime import datetime
 
+from openpype.lib import Logger
+from .autosave import get_autosave_files
+
+
+logger = Logger.get_logger(__name__)
+
+
+def is_headless():
+    """
+    Returns:
+        bool: headless
+    """
+    from qtpy import QtWidgets
+    return QtWidgets.QApplication.instance() is None
 
 def file_extensions():
     return [".nk"]
@@ -19,13 +35,38 @@ def save_file(filepath):
     nuke.Root().setModified(False)
 
 
+def return_autosave_candidate(filepath):
+    if is_headless():
+        return
+
+    autosaves = get_autosave_files(filepath)
+    logger.info(f"OpenPype found these autosaves: {autosaves}")
+    if len(autosaves) > 0:
+        autosave = autosaves[-1]
+        if (Path(autosave) != Path(filepath)
+            and Path(autosave).stat().st_mtime>Path(filepath).stat().st_mtime):
+
+            # autosave = nuke.toNode("preferences")["AutoSaveName"].evaluate()
+            msg = f"Would you like to load the autosave file?\n{autosave}"
+            msg += f"\n{datetime.fromtimestamp(Path(autosave).stat().st_mtime)}"
+            if os.path.isfile(autosave) and nuke.ask(msg):
+                logger.info(f"Restoring autosave file: {filepath}")
+                return autosave
+
+
 def open_file(filepath):
     filepath = filepath.replace("\\", "/")
 
     # To remain in the same window, we have to clear the script and read
     # in the contents of the workfile.
+    logger.info(f"Opening file with OpenPype {filepath}")
     nuke.scriptClear()
-    nuke.scriptReadFile(filepath)
+    autosave = return_autosave_candidate(filepath)
+
+    file_to_open = autosave or filepath
+
+
+    nuke.scriptReadFile(file_to_open)
     nuke.Root()["name"].setValue(filepath)
     nuke.Root()["project_directory"].setValue(os.path.dirname(filepath))
     nuke.Root().setModified(False)

--- a/openpype/plugins/publish/extract_slate_global.py
+++ b/openpype/plugins/publish/extract_slate_global.py
@@ -450,7 +450,7 @@ class SlateCreator:
         cmd.append(self.get_chrome_path())
         cmd.append("--headless")
         cmd.append("--disable-logging")
-        cmd.append("--disable-gpu")
+        # cmd.append("--disable-gpu")
         cmd.append("--user-data-dir={}/chrome_logs".format(
             tempfile.gettempdir()
         ))

--- a/openpype/settings/defaults/project_settings/nuke.json
+++ b/openpype/settings/defaults/project_settings/nuke.json
@@ -6,7 +6,12 @@
             "load": "ctrl+alt+l",
             "manage": "ctrl+alt+m",
             "build_workfile": "ctrl+alt+b"
-        }
+        },
+        "autosave": {
+            "enabled": true,
+            "increments": 9
+         }
+
     },
     "imageio": {
         "enabled": false,

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
@@ -43,6 +43,27 @@
                             "label": "Build Workfile"
                         }
                     ]
+                },
+                {
+                    "type": "dict",
+                    "collapsible": true,
+                    "key": "autosave",
+                    "label": "Incremental autosave",
+                    "children": [
+                        {
+                            "type": "boolean",
+                            "key": "enabled",
+                            "label": "Enabled"
+                        },
+                        {
+                            "type": "number",
+                            "key": "increments",
+                            "label": "Number of rotating increments: (autosave1, autosave2...)",
+                            "minimum": 1,
+                            "maximum": 100,
+                            "decimal": 0
+                        }
+                    ]
                 }
             ]
         },

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_nuke.json
@@ -60,7 +60,7 @@
                             "key": "increments",
                             "label": "Number of rotating increments: (autosave1, autosave2...)",
                             "minimum": 1,
-                            "maximum": 100,
+                            "maximum": 9,
                             "decimal": 0
                         }
                     ]


### PR DESCRIPTION
## Brief description
Implementing incremental autosave for nuke as explained in [here](https://support.foundry.com/hc/en-us/articles/211501949-Q100158-Generating-multiple-autosaves-for-your-Nuke-script).

Adding two OpenPype settings for better control of this feature: `enabled` and `increments`
* `enabled` allows to enable and disable autosave per project, in case there is any unexpected problem with working files and this way we don't need to redistribute a new OpenPype version to remove the autosave.
* `increments`: allows to set up the number of rotating autosave increments per file

![image](https://github.com/user-attachments/assets/7163dfa4-bf75-4a6c-8f42-6c4cef432184)

Also adding interactive recovery.
Adding a prompt that allows users to load autosaves when found. This prompt is not to be confused with Nuke's one, which by default it is triggered if an `.autosave` (note no trailing numbers) is found. As all our autosaves have numbers now, Nuke's native menu won't appear, and only the OpenPype one will appear.

![image](https://github.com/user-attachments/assets/3ced6f34-fc7f-47bb-8afc-d6bfb07d9043)


NOTE: there is an old commit here regarding the `chrome.exe` `--disable-gpu` tag, this can be ignored as after that I did merge the latest changes in the main branch, so that commit is overwritten with whatever was committed afterwards, this can be checked in the list of changed files, only the ones regarding the autosave are present.