### PR TITLE
Addin two small requests for CSV in production

### DIFF
--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -80,14 +80,16 @@ def yield_csv_lines_from_repres(
     anatomy = Anatomy(prj)
     datetime_data = get_datetime_data()
     settings = get_project_settings(prj)["ftrack"]["user_handlers"]
-    settings = settings["delivery_action"]["csv_template_families"].get(anatomy_name)
-    if settings is None:
-        settings = [
+    tpl = settings["delivery_action"]["csv_template_families"].get(anatomy_name)
+    if tpl is None:
+        tpl = settings["delivery_action"]["csv_template_families"].get("default")
+    if tpl is None:
+        tpl = [
             {"column_name": "Errors", "column_value": "Failed to find CSV config"}
         ]
-    yield ",".join([d["column_name"] for d in settings])
+    yield ",".join([d["column_name"] for d in tpl])
     for repre in representations:
-        yield generate_csv_line_from_repre(prj, repre, anatomy, datetime_data, settings)
+        yield generate_csv_line_from_repre(prj, repre, anatomy, datetime_data, tpl)
 
 
 def generate_csv_from_representations(

--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -256,7 +256,8 @@ def augment_repre_with_ftrack_version_data(
 
     file = StringTemplate.format_strict_template(file["path"], data)
 
-    ctx["exr_includes_matte"] = "" if is_alpha_channel_empty(file) else "X"
+    # ctx["exr_includes_matte"] = "" if is_alpha_channel_empty(file) else "X"
+    ctx["exr_includes_matte"] = ""
     ctx["status"] = version["status"]["name"]
     ctx["notes"] = return_version_notes_for_csv(version)
     ctx["intent"] = return_intent_from_notes(ctx["notes"])

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -96,7 +96,9 @@
             "enabled": true,
             "mapping": {},
             "asset_types_to_skip": [],
-            "asset_prefix_to_skip": ["prerender"]
+            "asset_prefix_to_skip": [
+                "prerender"
+            ]
         },
         "next_task_update": {
             "enabled": true,
@@ -207,8 +209,18 @@
                 "Dailies_h264": "{root[delivery]}/{project[name]}/out/dailies/{yyyy}{mm}{dd}/{ftrack[listname]}/Review/{asset}_{task[short]}_DOG_{@version}<.{@frame}>.{ext}"
             },
             "create_client_review_default": false,
-            "csv_template_families":
-            {
+            "csv_intent_regex": [
+                "(WIP\\ [A-Z]+)|PAF(?=\\ \\-\\ )",
+                "(WIP(?=\\ \\-\\ ))",
+                "(FINAL\\ PENDING\\ TECH\\ CHECK(?=\\ \\-\\ ))",
+                "(FINAL\\ TECH\\ CHECKED(?=\\ \\-\\ ))",
+                "(APROVAL(?=\\ \\-\\ ))",
+                "(REFERENCE(?=\\ \\-\\ ))",
+                "(TEMP(?=\\ \\-\\ ))",
+                "(MARKETING(?=\\ \\-\\ ))",
+                "(TEST(?=\\ \\-\\ ))"
+            ],
+            "csv_template_families": {
                 "Finals": [
                     {
                         "column_name": "Vendor",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -248,8 +248,7 @@
                         {
                             "type": "dict-modifiable",
                             "key": "mapping",
-                            "object_type":
-                            {
+                            "object_type": {
                                 "type": "list",
                                 "object_type": "text"
                             }
@@ -439,13 +438,15 @@
                                     "minimum": 0,
                                     "maximum": 23,
                                     "decimal": 0
-                                }, {
+                                },
+                                {
                                     "label": "M:",
                                     "type": "number",
                                     "minimum": 0,
                                     "maximum": 59,
                                     "decimal": 0
-                                }, {
+                                },
+                                {
                                     "label": "S:",
                                     "type": "number",
                                     "minimum": 0,
@@ -546,11 +547,11 @@
                             "object_type": "text"
                         },
                         {
-                          "type": "separator"
+                            "type": "separator"
                         },
                         {
-                          "type": "label",
-                          "label": "Check \"Create project structure\" by default"
+                            "type": "label",
+                            "label": "Check \"Create project structure\" by default"
                         },
                         {
                             "type": "boolean",
@@ -676,15 +677,25 @@
                         },
                         {
                             "type": "label",
+                            "label": "List of regexes used to find the submission type from the notes written by the Supervisors"
+                        },
+                        {
+                            "type": "list",
+                            "key": "csv_intent_regex",
+                            "label": "CSV Intent Regex",
+                            "object_type": "text"
+                        },
+                        {
+                            "type": "label",
                             "label": "NOTE: Template keys can be All standard anatomy template data plus:\n- {ftrack[listname]}\n- {ftrack[username]}\n- {ftrack[category]}\n- {asset_data[duration]}\n- {asset_data[frameStart]}\n- {asset_data[frameEnd]}\n- {asset_data[duration]}\n- {asset_data[duration_no_slate]}\n- {asset_data[start]}\n- {asset_data[end]}\n- {episode_name}\n- {shot_name}\n- {status}\n- {version_info[name]}\n- {version_info[version]}\n- {version_info[full_name]}\n- {version_info[name]}_DOG_{version_info[padded_version]}\n- {notes[For Client]}\n- {notes[Client Feedback]}\n- {notes[...]}\n- {exr_includes_matte}\n- {intent[For Client]}\n- {intent[Submission Notes]}"
                         },
                         {
-                            "label":"CSV Template Families",
-                            "key":"csv_template_families",
-                            "type":"dict-modifiable",
+                            "label": "CSV Template Families",
+                            "key": "csv_template_families",
+                            "type": "dict-modifiable",
                             "collapsible": true,
                             "use_label_wrap": true,
-                            "object_type":{
+                            "object_type": {
                                 "type": "list",
                                 "collapsible": true,
                                 "object_type": {
@@ -1238,14 +1249,30 @@
                             "type": "enum",
                             "multiselection": true,
                             "enum_items": [
-                                {"openpype_version": "OpenPype version"},
-                                {"frame_start": "Frame start"},
-                                {"frame_end": "Frame end"},
-                                {"duration": "Duration"},
-                                {"width": "Resolution width"},
-                                {"height": "Resolution height"},
-                                {"fps": "FPS"},
-                                {"code": "Codec"}
+                                {
+                                    "openpype_version": "OpenPype version"
+                                },
+                                {
+                                    "frame_start": "Frame start"
+                                },
+                                {
+                                    "frame_end": "Frame end"
+                                },
+                                {
+                                    "duration": "Duration"
+                                },
+                                {
+                                    "width": "Resolution width"
+                                },
+                                {
+                                    "height": "Resolution height"
+                                },
+                                {
+                                    "fps": "FPS"
+                                },
+                                {
+                                    "code": "Codec"
+                                }
                             ]
                         }
                     ]


### PR DESCRIPTION
## Brief description
### Making exr_includes_matte column always blank
Michelangelo and Julia asked me for this as it may be unreliable to programmatically guess whether an exr contains a matte or not.
1. Matte can be in one frame and not in another.
2. There could be a matte but completely black or white and be a false positive.
3. Matte could be in a random channel, as opposed to always be in alpha.
4. Even if a DI matte was detected correctly maybe the intent of the supervisor was to no let the client know about this.
They will fill up this data on their own.

### CSV feature request
Also allowing for regex in settings to get the submission status by matching regex against the submitted note as supervisors are adding the status in the notes.