### PR TITLE
reducing popups further for other subprocesses

### DIFF
--- a/openpype/plugins/publish/extract_slate_global.py
+++ b/openpype/plugins/publish/extract_slate_global.py
@@ -482,7 +482,7 @@ class SlateCreator:
         #     capture_output=True
         # )
 
-        res = run_subprocess(cmd)
+        res = run_subprocess(cmd, creationflags=subprocess.CREATE_NO_WINDOW)
         self.log.debug(res)
 
         os.remove(html_temp_path)
@@ -524,7 +524,7 @@ class SlateCreator:
         #     capture_output=True
         # )
 
-        res = run_subprocess(cmd)
+        res = run_subprocess(cmd, creationflags=subprocess.CREATE_NO_WINDOW)
 
         return res
     
@@ -564,7 +564,7 @@ class SlateCreator:
         #     capture_output=True
         # )
 
-        res = run_subprocess(cmd, env=env)
+        res = run_subprocess(cmd, env=env, creationflags=subprocess.CREATE_NO_WINDOW)
 
         return res
 
@@ -594,7 +594,7 @@ class SlateCreator:
             # )
             # lines = res.stdout.decode("utf-8").replace(" ", "").splitlines()
 
-            res = run_subprocess(cmd, env=env)
+            res = run_subprocess(cmd, env=env, creationflags=subprocess.CREATE_NO_WINDOW)
             lines = res.replace(" ", "").splitlines()
 
             for line in lines:
@@ -653,7 +653,7 @@ class SlateCreator:
             #     capture_output=True,
             #     text=True
             # ).stdout.strip("\n")
-            tc = run_subprocess(cmd, env=env).strip("\n")
+            tc = run_subprocess(cmd, env=env, creationflags=subprocess.CREATE_NO_WINDOW).strip("\n")
             self.log.debug("{0}: New starting timecode Found: {1}".format(name, tc))
         except:
             self.log.debug("FFPROBE process failed, switching to default tc...")
@@ -687,7 +687,7 @@ class SlateCreator:
         # resolution = json.loads(
         #     res.stdout.decode("utf-8")
         # )["streams"][0]
-        res = run_subprocess(cmd, env=env)
+        res = run_subprocess(cmd, env=env, creationflags=subprocess.CREATE_NO_WINDOW)
         resolution = json.loads(res)["streams"][0]
         self.log.debug("{}: File resolution is: {}x{}".format(
             name,

--- a/openpype/plugins/publish/extract_tail_timecode.py
+++ b/openpype/plugins/publish/extract_tail_timecode.py
@@ -83,7 +83,7 @@ class ExtractTailTimecode(publish.Extractor):
             "-of", "csv=p=0",
             input.replace("\\", "/")
         ]
-        length = run_subprocess(cmd).strip("\n")
+        length = run_subprocess(cmd, creationflags=subprocess.CREATE_NO_WINDOW).strip("\n")
         return length
 
     def get_timecode_oiio(self, input):
@@ -103,7 +103,7 @@ class ExtractTailTimecode(publish.Extractor):
             "-v",
             input.replace("\\", "/")
         ]
-        res = run_subprocess(cmd)
+        res = run_subprocess(cmd, creationflags=subprocess.CREATE_NO_WINDOW)
         lines = res.replace(" ", "").splitlines()
         for line in lines:
             if line.lower().find("timecode") > 0:
@@ -144,7 +144,7 @@ class ExtractTailTimecode(publish.Extractor):
             "compact=print_section=0:nokey=1",
             input.replace("\\", "/")
         ]
-        tc = run_subprocess(cmd).strip("\n")
+        tc = run_subprocess(cmd, creationflags=subprocess.CREATE_NO_WINDOW).strip("\n")
         return tc
 
     def process(self, instance):

--- a/openpype/plugins/publish/extract_timecode.py
+++ b/openpype/plugins/publish/extract_timecode.py
@@ -65,7 +65,7 @@ class ExtractTimecode(publish.Extractor):
         #     capture_output=True
         # )
         # lines = res.stdout.decode("utf-8", errors="ignore").replace(" ", "").splitlines()
-        res = run_subprocess(cmd)
+        res = run_subprocess(cmd, creationflags=subprocess.CREATE_NO_WINDOW)
         lines = res.replace(" ", "").splitlines()
         found_timecodes = []
         tc = None
@@ -102,7 +102,7 @@ class ExtractTimecode(publish.Extractor):
         #     ).stdout
         # )
         # lines = res.replace(" ", "").splitlines()
-        res = json.loads(run_subprocess(cmd))
+        res = json.loads(run_subprocess(cmd, creationflags=subprocess.CREATE_NO_WINDOW))
         tc = list(set(self._finditems(res, "timecode")))[0]
         return tc
 


### PR DESCRIPTION
As there are other subprocesses other than `pythonw.exe`, like `ffmpeg` and `oiio` ones, I added the `CREATE_NO_WINDOW` flag to prevent flashing cmd pop up windows appear.

Note this is a windows flag, if we were using linux or mac, there would be an import error as `CREATE_NO_WINDOW` only exists in windows.