### PR TITLE
fixing bug to prevent unexpected behaviour in list

### DIFF
--- a/openpype/plugins/publish/extract_templated_transcode.py
+++ b/openpype/plugins/publish/extract_templated_transcode.py
@@ -185,7 +185,7 @@ class ExtractTemplatedTranscode(publish.Extractor):
 
                 self.log.debug("Destination staging dir is set as '{}'".format(new_repre["stagingDir"]))
 
-                orig_file_list = list(set(copy.deepcopy(new_repre["files"])))
+                orig_file_list = sorted(list(set(copy.deepcopy(new_repre["files"]))))
 
                 frame_start = int(instance.data["frameStart"])-int(instance.data["handleStart"])
                 frame_end = int(instance.data["frameEnd"])+int(instance.data["handleEnd"])


### PR DESCRIPTION
## Brief description
The `orig_file_list` variable was unsorted because it was a casted into a set to remove duplicates.
This made both `orig_file_list` and `first_frame` unsynced. Sorting `orig_file_list` afterwards fixed the issue.

## Description
Because this unsynced lists padded was 3 and sometimes it was 4, producing either 09## or just 9##. This is OK if the list is ordered, as the padding matches the frame, but being unsorted, padded 4 may be assigned to frame 995, thus creating 0995, then padding 3 may be assigned to frame 996 creating 996. This ultimately made clique find two different Collections, the 0 padded 3 integer frames and the rest.

![image](https://github.com/user-attachments/assets/30fa69be-7d21-4d60-8bb9-d5d7b63d30f2)
