### PR TITLE
adding rename CSV file feature

### DIFF
--- a/openpype/lib/ttd_op_utils.py
+++ b/openpype/lib/ttd_op_utils.py
@@ -7,7 +7,7 @@ from subprocess import Popen, PIPE
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 from collections import defaultdict
-from re import compile  as recomp, Pattern
+from re import compile  as recomp, Pattern, sub
 
 from ftrack_api.entity.asset_version import AssetVersion
 from openpype.settings import get_anatomy_settings, get_project_settings
@@ -295,6 +295,24 @@ def get_csv_path(created_files: List[str], pckg_name: str):
         )
 
 
+def modify_csv_file_name(prj: str, csv_file: str):
+    """Created as a request by Prod to give more control over the name of the
+    CSV filenames. This is done through a regex substitution pairs.
+    """
+
+    settings = get_project_settings(prj)["ftrack"]["user_handlers"]["delivery_action"]
+    inputs = settings["csv_filename_regex_sub_pairs"]["inputs"]
+
+    for item in inputs:
+        regex = item["regex"]
+        subs = item["substitution"]
+        logger.debug(f"CSV substitution regex is: {regex}")
+        logger.debug(f"CSV substitution string is: {subs}")
+        logger.debug(f"CSV filename is: {csv_file}")
+        csv_file = sub(regex, subs, csv_file)
+    
+    return csv_file
+
 def create_csv_in_download_folder(
     prj: str, name: str, repres: List[dict], anatomy_name: str
 ):
@@ -382,11 +400,18 @@ def handle_csv(
         csv_file = get_csv_path(report["created_files"], name)
     except IndexError as e:
         raise NotImplementedError(report) from e
+    
 
     if csv_file is not None:
+
+        try:
+            modify_csv_file_name(prj, csv_file)
+        except Exception as e:
+            logger.critical(f"Failed to apply mods on CSV name due to: {e}")        
         generate_csv_from_representations(prj, repres, csv_file, cfg)
         logger.info(f"CSV saved in {csv_file}")
     else:
+        name = modify_csv_file_name(prj, name)
         try:
             create_csv_in_download_folder(prj, name, repres, cfg)
         except:

--- a/openpype/settings/defaults/project_settings/ftrack.json
+++ b/openpype/settings/defaults/project_settings/ftrack.json
@@ -208,6 +208,14 @@
                 "Dailies": "{root[delivery]}/{project[name]}/out/dailies/{yyyy}{mm}{dd}/{ftrack[listname]}/AVID/{asset}_{task[short]}_DOG_{@version}<.{@frame}>.{ext}",
                 "Dailies_h264": "{root[delivery]}/{project[name]}/out/dailies/{yyyy}{mm}{dd}/{ftrack[listname]}/Review/{asset}_{task[short]}_DOG_{@version}<.{@frame}>.{ext}"
             },
+            "csv_filename_regex_sub_pairs": {
+                "inputs": [
+                    {
+                        "regex": "",
+                        "substitution": ""
+                    }
+                ]
+            },
             "csv_intent_regex": [
                 "(WIP\\ [A-Z]+)|PAF(?=\\ \\-\\ )",
                 "(WIP(?=\\ \\-\\ ))",

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_ftrack.json
@@ -680,6 +680,33 @@
                             "label": "List of regexes used to find the submission type from the notes written by the Supervisors"
                         },
                         {
+                            "key": "csv_filename_regex_sub_pairs",
+                            "type": "dict",
+                            "label": "CSV Filename Substitution Regex",
+                            "collapsible": true,
+                            "children": [
+                                {
+                                    "type": "list",
+                                    "key": "inputs",
+                                    "object_type": {
+                                        "type": "dict",
+                                        "children": [
+                                            {
+                                                "type": "text",
+                                                "key": "regex",
+                                                "label": "Regex"
+                                            },
+                                            {
+                                                "type": "text",
+                                                "key": "substitution",
+                                                "label": "Substitution String"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "type": "list",
                             "key": "csv_intent_regex",
                             "label": "CSV Intent Regex",


### PR DESCRIPTION
## Brief description
Production asked me to have more control over the name of the CSV file in the deliveries

## Description
A client needs the same name for both FINALS and DNx's CSV files. The CSV file inherits the name of the Ftrack list, which are unique, so to prevent adding a human step where the CSV file is renamed from the Ftrack list name, to match the expected name, I added settings for regex substitution.
If there is any regex/substitution pair in the project settings, they weill be applied to the CSV file.

![image](https://github.com/user-attachments/assets/5d9af4a2-a91f-4344-b6db-4cfb024d6fd9)
