### PR TITLE
RV-OCIO workflow

### DIFF
--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -456,6 +456,8 @@ class ORVAction(BaseAction):
         ocio_files = [get_ocio_file_from_component(f[0]) for f in paths]
         ocio_files = list({f.as_posix() for f in ocio_files if f is not None})
 
+        if not user_values["load_ocio_files"]:
+            ocio_files = list()
 
         # START OF OPENRVPUSH PROC
         src = "from openrv_tools_22dogs import orvpush_inputs_callback\n"

--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import re
 import traceback
-from typing import Callable, List, Tuple, Optional
+from typing import Callable, List, Tuple, Optional, Iterator
 from pathlib import Path
 
 import ftrack_api
@@ -10,6 +10,53 @@ from ftrack_api import Session
 from ftrack_api.entity.asset_version import AssetVersion
 from openpype_modules.ftrack.lib import BaseAction, statics_icon # type: ignore
 
+def yield_ocio_files_from_component(comp_path: str) -> Iterator[Path]:
+    """Yields OCIO files from a given component path.
+
+    The reason why `comp_path` is not just a common path, is because a `comp_path`
+    is understood as a published file which is located within a "publish" structure
+    and thus it has a "publish" folder at some point in its hierarchy.
+
+
+    Parameters
+    ----------
+    comp_path : str
+        The path to the component.
+
+    Yields
+    ------
+    Path
+        Paths to OCIO files.
+    """
+
+    if "publish" not in Path(comp_path).parts:
+        return
+    path = next(p for p in Path(comp_path).parents if str(p).endswith("publish"))
+    yield from path.rglob("*.ocio")
+
+
+def get_ocio_file_from_component(comp_path: str) -> Path:
+    """Returns the latest OCIO file from a given component path.
+
+    The reason why `comp_path` is not just a common path, is because a `comp_path`
+    is understood as a published file which is located within a "publish" structure
+    and thus it has a "publish" folder at some point in its hierarchy.
+
+    Parameters
+    ----------
+    comp_path : str
+        The path to the component.
+
+    Returns
+    -------
+    Path
+        Path to the latest OCIO file.
+    """
+
+    candidates = list(yield_ocio_files_from_component(comp_path))
+    if not candidates:
+        return
+    return max(*candidates, key=lambda x: x.stat().st_mtime)
 
 
 class ORVAction(BaseAction):
@@ -265,6 +312,12 @@ class ORVAction(BaseAction):
                     "name": "load_previous_version",
                     "value": False
                 },
+                {
+                    "label": "<div><b>Load OCIO Files (experimental)</b></div><div style=\"font-size: 8pt;\">(All components)</div>",
+                    "type": "boolean",
+                    "name": "load_ocio_files",
+                    "value": False
+                },
             ],
         )
         return items
@@ -357,7 +410,7 @@ class ORVAction(BaseAction):
                 "TTD_STUDIO_LOCAL_SOFTWARE":'"C:/Program Files"',
                 "TTD_STUDIO_COMMON_SOFTWARE":"R:/shared_software/common",
                 "TTD_STUDIO_SHARED_SOFTWARE":"R:/shared_software/windows",
-                "OCIO":"R:/ocioconfigs/aces_1.2/config.ocio",
+                # "OCIO":"R:/ocioconfigs/aces_1.2/config.ocio",
                 "solidangle_LICENSE":"5053@appserver",
                 "peregrinel_LICENSE":"5080@appserver",
                 "MAYA_VERSION":"2022",
@@ -384,13 +437,20 @@ class ORVAction(BaseAction):
             
         comp_locations.sort(key = order_lambda)
 
+
+
         paths: List[Tuple[str]] = list(self.get_paths_list( comp_locations))
         if not paths:
             return {"success": True, "message": "No valid components where found in the server."}
 
+        ocio_files = [get_ocio_file_from_component(f[0]) for f in paths]
+        ocio_files = list({f.as_posix() for f in ocio_files if f is not None})
+
+
         # START OF OPENRVPUSH PROC
         src = "from openrv_tools_22dogs import orvpush_inputs_callback\n"
-        signature = f"({', '.join([str(i) for i in [paths, no_slate, fps]])})"
+        src += "from pathlib import Path\n"
+        signature = f"({', '.join([str(i) for i in [paths, no_slate, fps, ocio_files]])})"
         src += "orvpush_inputs_callback" + signature
 
         if entities[0].entity_type == "FileComponent":
@@ -398,9 +458,24 @@ class ORVAction(BaseAction):
         else:
             prj = entities[0]["project"]["full_name"]
 
+
+        if Path("C:/Program Files/OpenRV/bin/rvpush.exe").exists():
+            self.orvpush_path = "C:/Program Files/OpenRV/bin/rvpush.exe"
+
+
         cmd = [self.orvpush_path, "-tag", prj, "py-exec", src]
         self.log.debug(f"Running ORVPUSH: {cmd}")
-        rv_push_process = subprocess.Popen(cmd, env=return_ttd_envs())
+
+        env = return_ttd_envs()
+        if not user_values["load_ocio_files"]:
+            ocio_files = list()
+            env["OCIO"] = "R:/ocioconfigs/aces_1.2/config.ocio",
+        # if ocio_files:
+        #     env["OCIO"] = ocio_files[0]
+        
+        #     self.log.info(f"OCIO config set to {ocio_files[0]}")
+
+        rv_push_process = subprocess.Popen(cmd, env=env)
         msg = f"ORV Launching: {fps} FPS with {'no' if no_slate else ''} slate."
         return {"success": True, "message": msg}
 

--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -469,7 +469,7 @@ class ORVAction(BaseAction):
         env = return_ttd_envs()
         if not user_values["load_ocio_files"]:
             ocio_files = list()
-            env["OCIO"] = "R:/ocioconfigs/aces_1.2/config.ocio",
+            env["OCIO"] = "R:/ocioconfigs/aces_1.2/config.ocio"
         # if ocio_files:
         #     env["OCIO"] = ocio_files[0]
         

--- a/openpype/modules/ftrack/event_handlers_user/action_orv.py
+++ b/openpype/modules/ftrack/event_handlers_user/action_orv.py
@@ -4,6 +4,7 @@ import re
 import traceback
 from typing import Callable, List, Tuple, Optional, Iterator
 from pathlib import Path
+from re import sub
 
 import ftrack_api
 from ftrack_api import Session
@@ -235,7 +236,16 @@ class ORVAction(BaseAction):
         seen = list()
         for i, cpath in enumerate(comp_locations):
             path = Path(cpath.get("resource_identifier"))
-            if path is None or not path.exists():
+            if path is None:
+                self.log.warning(f"File {path} from {cpath['component']['name']} failed to be found. Ignoring it.")
+                continue
+            path_2 = Path(sub("(?<=[\.])\d{4,}(?=[\.]|$)", "1001", path.as_posix()))
+            if not path.exists() and path_2.exists():
+                # path may be with frame 1000 in Ftrack and that frame may not exist
+                # in the file system we need to check for frame 1001 instead
+                self.log.info(f"{path} failed to be found, using {path_2} instead.")
+                path = path_2
+            elif not path.exists():
                 self.log.warning(f"File {path} from {cpath['component']['name']} failed to be found. Ignoring it.")
                 continue
             if cpath['component']["version_id"] not in seen:


### PR DESCRIPTION
## Brief description
Required setup for handling OCIO files in RV.

## Description
As all the logic happens in the RV package, this is a very minimal mod on the ORV action, it just forwards the OCIO files.
We should probably use mongodb to find the fitest OCIO file, but for now the implementation is simply a glob that looks for *.ocio files in the publish subfolders and returns the one with the latest modification stat.
By default the OCIO config is OFF so that testing can be done without affecting the usual workflow.

![image](https://github.com/user-attachments/assets/04925402-a3c9-4fb9-a924-59fa09f17356)

## Additional notes
I have also added a fix, as sometimes the reference file that appears in the component doesn't exists in the file system, this made the OpenRV app to fallback to a different component, for instance, if in ftrack the component path exr was myfile.1000.ext, this frame may not be there, so now it will looks for frame 1001 additionally.



