### PR TITLE
fixing errors reported by Edit

### DIFF
--- a/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
+++ b/openpype/modules/ftrack/plugins/publish/integrate_ftrack_api.py
@@ -54,22 +54,26 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
 
         try:
             source = None
+            current_project_name = instance.context.data.get(
+                "projectEntity", {}).get("name", os.getenv("AVALON_PROJECT")
+            )
+            
             if instance.data["family"] == "gather" and "gather.farm" not in instance.data["families"]:
-                root = session.query("TypedContext where name is '{}' and project_id is '{}'".format(
+                root = session.query("TypedContext where name is '{}' and project.full_name is '{}'".format(
                     instance.data["gather_root_name"],
-                    instance.data["gather_project_id"])
+                    current_project_name)
                     ).one()
-                source = session.query("AssetVersion where id is '{}'".format(
-                    instance.data["gather_ftrack_source_id"])).one()
+                source = session.query(
+                    f"AssetVersion where id is '{instance.data['gather_ftrack_source_id']}' "
+                    f"and project.full_name is '{current_project_name}'").one()
                 asset_data = {
                     "name": instance.data["gather_asset_name"],
                     "parent_id": root["id"],
                 }
 
-                asset_entity = session.query("Shot where name is '{}' and parent.name is '{}'".format(
-                    asset_data["name"],
-                    root["name"]
-                )).first()
+                asset_entity = session.query(
+                    f"Shot where name is '{asset_data['name']}' and parent.name is "
+                    f"'{root['name']}' and project.full_name is '{current_project_name}'").first()
                 if asset_entity is not None:
                     parent_entity = asset_entity
                 else:
@@ -78,13 +82,16 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
                 self.log.info("Created new container Asset with data: {}.".format(asset_data))
                 instance.data["asset"] = asset_data["name"]
                 instance.data["task"] = None
+
             elif instance.data.get("renderIngestDeadline", False):
                 task_name = instance.data.get("task", {})
                 if isinstance(task_name, dict):
                     task_name = task_name.get("name", "")
                 asset_name = instance.data.get("asset", "")
                 self.log.debug(f"Will try to match task: '{task_name}' with asset name {asset_name}")
-                task_entity = session.query(f"Task where name is '{task_name}' and parent.name is '{asset_name}'").one()
+                task_entity = session.query(
+                    f"Task where name is '{task_name}' and parent.name is '{asset_name}' "
+                    f"and project.full_name is '{current_project_name}'").first()
                 parent_entity = task_entity["parent"]
 
             self.integrate_to_ftrack(

--- a/openpype/plugins/publish/collect_gather_data.py
+++ b/openpype/plugins/publish/collect_gather_data.py
@@ -6,8 +6,59 @@ import pyblish.api
 
 from openpype.client import (
     get_asset_by_name,
-    get_last_version_by_subset_name
+    get_last_version_by_subset_name,
+    get_representations,
+    get_subsets
 )
+
+
+def yield_elegible_gather_subset_names(prj: str, gather_asset_name: str, target_task: str):
+    """Yield eligible subset names based on project, asset names and task.
+
+    This function identifies subsets starting with 'gather' that have
+    representations matching the target task. It yields each valid subset name
+    as it finds them.
+
+    Parameters
+    ----------
+    prj : str
+        The name of the project.
+    gather_asset_name : str
+        The name of the asset to gather data from.
+    target_task : str
+        The name of the task to filter representations by.
+
+    Yields
+    ------
+    subset_name : str
+        Names of eligible subsets that meet the criteria.
+
+    Notes
+    -----
+    - The function stops checking further representations once a match is found,
+      improving efficiency.
+    """
+    asset = get_asset_by_name(prj, gather_asset_name)
+
+    gather_subsets = [
+        s
+        for s in get_subsets(prj, asset_ids=[asset["_id"]])
+        if s["name"].startswith("gather")
+    ]
+
+    for subset in gather_subsets:
+        latest_version = get_last_version_by_subset_name(
+            prj, subset["name"], asset_name=gather_asset_name
+        )
+        repres = get_representations(
+            prj, version_ids=[latest_version["_id"]], fields=["context"]
+        )
+        for repre in repres:
+            if repre["context"]["task"]["name"] == target_task:
+                print(f"Found elegible subset name: {subset['name']}")
+                yield subset["name"]
+                break
+
 
 class CollectGatherData(pyblish.api.InstancePlugin):
     """
@@ -40,23 +91,48 @@ class CollectGatherData(pyblish.api.InstancePlugin):
             "short": task_short
         }
 
-    def get_last_version(self, instance):
-        self.log.debug("Querying latest versions for instances.")
-        project_name = instance.data["project"]
-        asset_name = instance.data["asset"]
-        subset_name = instance.data["subset"]
-        asset_doc = get_asset_by_name(project_name, asset_name, fields=["_id"])
+    def get_last_version(self, instance: pyblish.api.Instance):
+        """Get the latest version number from eligible gather subsets.
 
-        last_version = get_last_version_by_subset_name(
-            project_name,
-            subset_name,
-            asset_doc["_id"],
-            asset_name,
-            fields=["name"]
-        )
+        This function retrieves the highest version number by querying
+        eligible gather subsets based on project, asset, and task. It
+        iterates through each subset to find the latest candidate version.
+
+        Parameters
+        ----------
+        instance : pyblish.api.Instance
+            An instance containing metadata about the current operation,
+            including 'project', 'asset', and 'task'.
+
+        Returns
+        -------
+        int or None
+            The highest version number found, or None if no valid versions
+            are available.
+        """
+        self.log.debug("Querying latest versions for instances.")
+        prj = instance.data["project"]
+        asset_name = instance.data["asset"]
+        self.log.info(instance.data)
+        task = instance.data["task"]
+        # subset_name = instance.data["subset"]
+        asset_doc = get_asset_by_name(prj, asset_name, fields=["_id"])
+
+        last_version = 0
+        for subset in yield_elegible_gather_subset_names(prj, asset_name, task):
+            candidate_version = get_last_version_by_subset_name(
+                prj,
+                subset,
+                asset_doc["_id"],
+                asset_name,
+                fields=["name"]
+            )
+            if not candidate_version:
+                continue
+            last_version = max(last_version, int(candidate_version["name"]))
 
         if last_version:
-            return last_version["name"]
+            return last_version
         else:
             return None
 


### PR DESCRIPTION
## ISSUE ONE: gather have more than one link
### Cause
The last version was chosen by the subset name as oposed of being chosen by task. If one task had more than one subset names that were elegible for gathering, the versioning picked up by each would be different.

### Fix
Implemented a function that yields the subset names based on task name and asset name, then I get the highest version number from all the subsets that belong to that task, so for each gather for a same task, now it will always up the version regardless the subset name.

## ISSUE TWO: gathers won't get integrated in ftrack
### Cause
In the integrate_ftrack_api there where two bugs:
1. some queries didn't filter by project, so some query.one() calls failed due to the same name existing in a different project.
2. one query had a query.one() when there could be more than one result, so we just use query.first() now. This fix was mentioned by Max.

### Fix
Implemented a function that yields the subset names based on task name and asset name, then I get the highest version number from all the subsets that belong to that task, so for each gather for a same task, now it will always up the version regardless the subset name.
